### PR TITLE
use typescript version of no-unused-expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -228,6 +228,8 @@ module.exports = {
           'error',
           { functions: false, typedefs: false, classes: false },
         ],
+        '@typescript-eslint/no-unused-expressions': 'warn',
+        'no-unused-expressions': 'off',
         'no-unused-vars': 0,
         'import/no-unresolved': 'off',
         'no-undef': 'off',


### PR DESCRIPTION
This makes code that uses optional chaining with function calls work without lint warnings:

```ts
someObj?.someAttr?.someFunc?.("this will lint");
```

See https://github.com/facebook/create-react-app/issues/8107#issuecomment-565365982 and https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining