### PR TITLE
add consistent type import rule

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -194,6 +194,7 @@ module.exports = {
       rules: {
         'import/first': 0,
         'import/extensions': ['error', 'never', { ts: 'never' }],
+        '@typescript-eslint/consistent-type-imports': 'warn',
         '@typescript-eslint/member-ordering': 'warn',
         '@typescript-eslint/consistent-type-definitions': [
           'error',


### PR DESCRIPTION
This adds the following eslint rule: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md


More on type imports:
- https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports