### PR TITLE
Working around an error caused by ggit types using private modifiers and calling typescript-json-schema without a tsconfig targets lower than that.

### DIFF
--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
     "make:docs": "yarn run typedoc --readme none --excludeInternal --excludeExternals --plugin typedoc-plugin-markdown  src/specification.ts src/validation.ts src/utils/convertFromV2ToV1.ts",
-    "make:schema": "npx typescript-json-schema src/specification.ts Project -o ./src/json/specification.json --strictNullChecks=true --required=true --titles=true --noExtraProps=true  --validationKeywords errorMessage validationRules",
+    "make:schema": "npx typescript-json-schema ./tsconfig.schemagen.json Project -o ./src/json/specification.json --strictNullChecks=true --required=true --titles=true --noExtraProps=true  --validationKeywords errorMessage validationRules",
     "prepare": "yarn run build",
     "watch": "tsc -b -w",
     "build": "yarn run make:schema && tsc -b"

--- a/packages/project/src/json/specification.json
+++ b/packages/project/src/json/specification.json
@@ -681,10 +681,10 @@
                             "$ref": "#/definitions/GeoJSON.GeometryCollection"
                         },
                         {
-                            "$ref": "#/definitions/GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>"
+                            "$ref": "#/definitions/GeoJSON.Feature<GeoJSON.Geometry,{[name:string]:any;}>"
                         },
                         {
-                            "$ref": "#/definitions/GeoJSON.FeatureCollection<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>"
+                            "$ref": "#/definitions/GeoJSON.FeatureCollection<GeoJSON.Geometry,{[name:string]:any;}>"
                         }
                     ],
                     "description": "The geographic boundaries (defined as GeoJSON) associated with crop management practices.\n\nFor additional guidance and limitation of boundary files, [refer to the FAQ here](https://docs.google.com/document/d/1vnJKwFzU6drCjTD-eVXUK_59togcmROliyOU1y8Ne1U/edit?ts=5ed8f2d1#heading=h.fbiiknhrzhg8)",
@@ -723,7 +723,7 @@
             "title": "Field",
             "type": "object"
         },
-        "GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>": {
+        "GeoJSON.Feature<GeoJSON.Geometry,{[name:string]:any;}>": {
             "additionalProperties": false,
             "description": "A feature object which contains a geometry and associated properties.\nhttps://tools.ietf.org/html/rfc7946#section-3.2",
             "properties": {
@@ -813,18 +813,11 @@
                     ]
                 },
                 "properties": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": {
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
+                    "additionalProperties": {
+                    },
                     "description": "Properties associated with this feature.",
-                    "title": "properties"
+                    "title": "properties",
+                    "type": "object"
                 },
                 "type": {
                     "description": "Specifies the type of GeoJSON object.",
@@ -840,10 +833,10 @@
                 "properties",
                 "type"
             ],
-            "title": "GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>",
+            "title": "GeoJSON.Feature<GeoJSON.Geometry,{[name:string]:any;}>",
             "type": "object"
         },
-        "GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>_1": {
+        "GeoJSON.Feature<GeoJSON.Geometry,{[name:string]:any;}>_1": {
             "additionalProperties": false,
             "description": "A feature object which contains a geometry and associated properties.\nhttps://tools.ietf.org/html/rfc7946#section-3.2",
             "properties": {
@@ -933,18 +926,11 @@
                     ]
                 },
                 "properties": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": {
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
+                    "additionalProperties": {
+                    },
                     "description": "Properties associated with this feature.",
-                    "title": "properties"
+                    "title": "properties",
+                    "type": "object"
                 },
                 "type": {
                     "description": "Specifies the type of GeoJSON object.",
@@ -960,10 +946,10 @@
                 "properties",
                 "type"
             ],
-            "title": "GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>_1",
+            "title": "GeoJSON.Feature<GeoJSON.Geometry,{[name:string]:any;}>_1",
             "type": "object"
         },
-        "GeoJSON.FeatureCollection<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>": {
+        "GeoJSON.FeatureCollection<GeoJSON.Geometry,{[name:string]:any;}>": {
             "additionalProperties": false,
             "description": "A collection of feature objects.\n https://tools.ietf.org/html/rfc7946#section-3.3",
             "properties": {
@@ -1019,7 +1005,7 @@
                 },
                 "features": {
                     "items": {
-                        "$ref": "#/definitions/GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>_1"
+                        "$ref": "#/definitions/GeoJSON.Feature<GeoJSON.Geometry,{[name:string]:any;}>_1"
                     },
                     "title": "features",
                     "type": "array"
@@ -1037,7 +1023,7 @@
                 "features",
                 "type"
             ],
-            "title": "GeoJSON.FeatureCollection<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>",
+            "title": "GeoJSON.FeatureCollection<GeoJSON.Geometry,{[name:string]:any;}>",
             "type": "object"
         },
         "GeoJSON.GeometryCollection": {

--- a/packages/project/tsconfig.schemagen.json
+++ b/packages/project/tsconfig.schemagen.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2018",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/specification.ts"
+  ]
+}


### PR DESCRIPTION
This introduces some minor changes in the schema.  I'm not sure why GeoJsonProperties
in particular is getting resolved out into the alised value but it remains functionally
correct as far as I can tell.
