### PR TITLE
prefer toStrictEqual

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -171,6 +171,10 @@ module.exports = {
         extensions: allExtensions,
       },
     ],
+    /**
+     * jest rules
+     */
+    'jest/prefer-strict-equal': 'warn',
   },
   overrides: [
     {


### PR DESCRIPTION
adds an eslint rule to prefer `toStrictEqual` over `toEqual`

https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-strict-equal.md