### PR TITLE
Detect, remove, flag event date edge cases ("Truterra problem")

### DIFF
--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -51,6 +51,10 @@ export const Errors = {
       message:
         'No more than 16 irrigation event data entries can be specified for a crop year.',
     },
+    priorYearEdgeCaseError: {
+      message:
+        'This event must be entered manually, there is not yet a crop in the same year as this event.',
+    },
   },
   unknownErrorCode: {
     unknownErrorType: {

--- a/packages/project/src/utils/__tests__/v1-utils.test.ts
+++ b/packages/project/src/utils/__tests__/v1-utils.test.ts
@@ -34,6 +34,58 @@ const exampleV1DataForErrorTests: V1Data = {
           srid: '4326',
           cropYears: [
             {
+              cropYear: 2014,
+              crops: [
+                {
+                  version: 2,
+                  cropName: 'corn',
+                  type: 'annual crop',
+                  cropNumber: 1,
+                  classification: 'corn',
+                  datePlanted: '03/30/2014',
+                  // The two 2013 fertilizer events should create errors.
+                  fertilizerEvents: [
+                    {
+                      date: '11/20/2013',
+                      type: 'Mixed Blends',
+                      productName: 'DAP',
+                      lbsOfN: 18.78,
+                      area: 51.69,
+                      quantityUnit: 'lbs/acre',
+                    },
+                    {
+                      date: '11/20/2013',
+                      type: 'Mixed Blends',
+                      productName: 'Potash',
+                      lbsOfN: null,
+                      area: 51.69,
+                      quantityUnit: 'lbs/acre',
+                    },
+                    {
+                      date: '03/18/2014',
+                      type: 'Mixed Blends',
+                      productName: 'Anhydrous Ammonia',
+                      lbsOfN: 110,
+                      area: 51.69,
+                      quantityUnit: 'lbs/acre',
+                    },
+                  ],
+                  harvestOrKillEvents: [],
+                  irrigationEvents: [],
+                  limingEvents: [],
+                  organicMatterEvents: [],
+                  tillageEvents: [
+                    {
+                      classification: 'mulch tillage',
+                      type: 'mulch tillage',
+                      date: '03/29/2014',
+                    },
+                  ],
+                  burningEvents: [],
+                },
+              ],
+            },
+            {
               // acceptable data values
               cropYear: 2015,
               crops: [
@@ -463,6 +515,41 @@ const expectedFilteredV1Data: V1Data = {
           srid: '4326',
           cropYears: [
             {
+              cropYear: 2014,
+              crops: [
+                {
+                  version: 2,
+                  cropName: 'corn',
+                  type: 'annual crop',
+                  cropNumber: 1,
+                  classification: 'corn',
+                  datePlanted: '03/30/2014',
+                  fertilizerEvents: [
+                    {
+                      date: '03/18/2014',
+                      type: 'Mixed Blends',
+                      productName: 'Anhydrous Ammonia',
+                      lbsOfN: 110,
+                      area: 51.69,
+                      quantityUnit: 'lbs/acre',
+                    },
+                  ],
+                  harvestOrKillEvents: [],
+                  irrigationEvents: [],
+                  limingEvents: [],
+                  organicMatterEvents: [],
+                  tillageEvents: [
+                    {
+                      classification: 'mulch tillage',
+                      type: 'mulch tillage',
+                      date: '03/29/2014',
+                    },
+                  ],
+                  burningEvents: [],
+                },
+              ],
+            },
+            {
               cropYear: 2015,
               crops: [
                 {
@@ -713,6 +800,34 @@ describe('collectV1Errors', () => {
           eventType: 'tillageEvent',
           eventDate: '04/25/2017',
           datePlanted: '03/30/2016',
+        }
+      ),
+      new ContextualError(
+        'This event must be entered manually, there is not yet a crop in the same year as this event.',
+        {
+          field: 'ExampleFieldset1',
+          event: {
+            date: '11/20/2013',
+            type: 'Mixed Blends',
+            productName: 'DAP',
+            lbsOfN: 18.78,
+            area: 51.69,
+            quantityUnit: 'lbs/acre',
+          },
+        }
+      ),
+      new ContextualError(
+        'This event must be entered manually, there is not yet a crop in the same year as this event.',
+        {
+          field: 'ExampleFieldset1',
+          event: {
+            date: '11/20/2013',
+            type: 'Mixed Blends',
+            productName: 'Potash',
+            lbsOfN: null,
+            area: 51.69,
+            quantityUnit: 'lbs/acre',
+          },
         }
       ),
     ];

--- a/packages/project/src/utils/v1-utils.ts
+++ b/packages/project/src/utils/v1-utils.ts
@@ -47,112 +47,123 @@ const checkEventDates = (
   errorCollector: ErrorCollector
 ) => {
   const filteredCrop = { ...crop };
-  filteredCrop.harvestOrKillEvents = [];
-  crop.harvestOrKillEvents?.forEach((harvestEvent) => {
-    if (eventDateIsOutOfRange(crop.datePlanted, harvestEvent.date)) {
-      errorCollector.collectKeyedError(
-        'projectDataError:cropEventDateValidationRuleViolation',
-        {
-          field: fieldSetName,
-          crop: crop.cropName,
-          eventType: 'harvestEvent',
-          eventDate: harvestEvent.date,
-          datePlanted: crop.datePlanted,
-        }
+  filteredCrop.harvestOrKillEvents = crop.harvestOrKillEvents?.filter(
+    (event) => {
+      const dateIsOutOfRange = eventDateIsOutOfRange(
+        crop.datePlanted,
+        event.date
       );
-    } else {
-      filteredCrop.harvestOrKillEvents.push(harvestEvent);
+      if (dateIsOutOfRange) {
+        errorCollector.collectKeyedError(
+          'projectDataError:cropEventDateValidationRuleViolation',
+          {
+            field: fieldSetName,
+            crop: crop.cropName,
+            eventType: 'harvestEvent',
+            eventDate: event.date,
+            datePlanted: crop.datePlanted,
+          }
+        );
+      }
+      return !dateIsOutOfRange;
     }
-  });
-  filteredCrop.tillageEvents = [];
-  crop.tillageEvents?.forEach((tillageEvent) => {
-    if (eventDateIsOutOfRange(crop.datePlanted, tillageEvent.date)) {
+  );
+  filteredCrop.tillageEvents = crop.tillageEvents?.filter((event) => {
+    const dateIsOutOfRange = eventDateIsOutOfRange(
+      crop.datePlanted,
+      event.date
+    );
+    if (dateIsOutOfRange) {
       errorCollector.collectKeyedError(
         'projectDataError:cropEventDateValidationRuleViolation',
         {
           field: fieldSetName,
           crop: crop.cropName,
           eventType: 'tillageEvent',
-          eventDate: tillageEvent.date,
+          eventDate: event.date,
           datePlanted: crop.datePlanted,
         }
       );
-    } else {
-      filteredCrop.tillageEvents.push(tillageEvent);
     }
+    return !dateIsOutOfRange;
   });
-  filteredCrop.limingEvents = [];
-  crop.limingEvents?.forEach((limingEvent) => {
-    if (eventDateIsOutOfRange(crop.datePlanted, limingEvent.date)) {
+  filteredCrop.limingEvents = crop.limingEvents?.filter((event) => {
+    const dateIsOutOfRange = eventDateIsOutOfRange(
+      crop.datePlanted,
+      event.date
+    );
+    if (dateIsOutOfRange) {
       errorCollector.collectKeyedError(
         'projectDataError:cropEventDateValidationRuleViolation',
         {
           field: fieldSetName,
           crop: crop.cropName,
           eventType: 'limingEvent',
-          eventDate: limingEvent.date,
+          eventDate: event.date,
           datePlanted: crop.datePlanted,
         }
       );
-    } else {
-      filteredCrop.limingEvents.push(limingEvent);
     }
+    return !dateIsOutOfRange;
   });
-  filteredCrop.organicMatterEvents = [];
-  crop.organicMatterEvents?.forEach((organicMatterEvent) => {
-    if (eventDateIsOutOfRange(crop.datePlanted, organicMatterEvent.date)) {
-      errorCollector.collectKeyedError(
-        'projectDataError:cropEventDateValidationRuleViolation',
-        {
-          field: fieldSetName,
-          crop: crop.cropName,
-          eventType: 'organicMatterEvent',
-          eventDate: organicMatterEvent.date,
-          datePlanted: crop.datePlanted,
-        }
+  filteredCrop.organicMatterEvents = crop.organicMatterEvents?.filter(
+    (event) => {
+      const dateIsOutOfRange = eventDateIsOutOfRange(
+        crop.datePlanted,
+        event.date
       );
-    } else {
-      filteredCrop.organicMatterEvents.push(organicMatterEvent);
+      if (dateIsOutOfRange) {
+        errorCollector.collectKeyedError(
+          'projectDataError:cropEventDateValidationRuleViolation',
+          {
+            field: fieldSetName,
+            crop: crop.cropName,
+            eventType: 'organicMatterEvent',
+            eventDate: event.date,
+            datePlanted: crop.datePlanted,
+          }
+        );
+      }
+      return !dateIsOutOfRange;
     }
-  });
-  filteredCrop.fertilizerEvents = [];
-  crop.fertilizerEvents?.forEach((fertilizerEvent) => {
-    if (eventDateIsOutOfRange(crop.datePlanted, fertilizerEvent.date)) {
+  );
+  filteredCrop.fertilizerEvents = crop.fertilizerEvents?.filter((event) => {
+    const dateIsOutOfRange = eventDateIsOutOfRange(
+      crop.datePlanted,
+      event.date
+    );
+    if (dateIsOutOfRange) {
       errorCollector.collectKeyedError(
         'projectDataError:cropEventDateValidationRuleViolation',
         {
           field: fieldSetName,
           crop: crop.cropName,
           eventType: 'fertilizerEvent',
-          eventDate: fertilizerEvent.date,
+          eventDate: event.date,
           datePlanted: crop.datePlanted,
         }
       );
-    } else {
-      filteredCrop.fertilizerEvents.push(fertilizerEvent);
     }
+    return !dateIsOutOfRange;
   });
-  filteredCrop.irrigationEvents = [];
-  crop.irrigationEvents?.forEach((irrigationEvent) => {
-    if (
-      eventDateIsOutOfRange(
-        crop.datePlanted,
-        irrigationEvent.endDate ?? irrigationEvent.date
-      )
-    ) {
+  filteredCrop.irrigationEvents = crop.irrigationEvents?.filter((event) => {
+    const dateIsOutOfRange = eventDateIsOutOfRange(
+      crop.datePlanted,
+      event.endDate ?? event.date
+    );
+    if (dateIsOutOfRange) {
       errorCollector.collectKeyedError(
         'projectDataError:cropEventDateValidationRuleViolation',
         {
           field: fieldSetName,
           crop: crop.cropName,
           eventType: 'irrigationEvent',
-          eventDate: irrigationEvent.date,
+          eventDate: event.date,
           datePlanted: crop.datePlanted,
         }
       );
-    } else {
-      filteredCrop.irrigationEvents.push(irrigationEvent);
     }
+    return !dateIsOutOfRange;
   });
   return filteredCrop;
 };
@@ -178,42 +189,32 @@ const checkFertilizerTillageDateEdgeCase = (
   errorCollector: ErrorCollector
 ): V1Crop => {
   const filteredCrop = { ...crop };
-  const filteredFertilizerEvents: V1FertilizerEvent[] = [];
-  const filteredTillageEvents: V1TillageEvent[] = [];
-  crop.fertilizerEvents.forEach((fertilizerEvent) => {
-    const fertilizerEventYear = Number(
-      fertilizerEvent.date.split('/').slice(-1)
+  const earliestCropYearEventDateFilter = (
+    event: V1FertilizerEvent | V1TillageEvent
+  ): boolean => {
+    const eventDateIsBeforeEarliestCropYear = moment(event.date).isBefore(
+      moment(earliestCropYear, 'year')
     );
-    if (fertilizerEventYear < earliestCropYear) {
+    if (eventDateIsBeforeEarliestCropYear) {
       errorCollector.collectKeyedError(
         'projectDataError:priorYearEdgeCaseError',
         {
           field: fieldName,
-          event: fertilizerEvent,
+          event,
         }
       );
-    } else {
-      filteredFertilizerEvents.push(fertilizerEvent);
     }
-  });
-  crop.tillageEvents.forEach((tillageEvent) => {
-    const tillageEventYear = Number(tillageEvent.date.split('/').slice(-1));
-    if (tillageEventYear < earliestCropYear) {
-      errorCollector.collectKeyedError(
-        'projectDataError:priorYearEdgeCaseError',
-        {
-          field: fieldName,
-          event: tillageEvent,
-        }
-      );
-    } else {
-      filteredTillageEvents.push(tillageEvent);
-    }
-  });
-  filteredCrop.fertilizerEvents = filteredFertilizerEvents;
-  filteredCrop.tillageEvents = filteredTillageEvents;
+    return !eventDateIsBeforeEarliestCropYear;
+  };
+  filteredCrop.fertilizerEvents = crop.fertilizerEvents.filter(
+    earliestCropYearEventDateFilter
+  );
+  filteredCrop.tillageEvents = crop.tillageEvents.filter(
+    earliestCropYearEventDateFilter
+  );
   return filteredCrop;
 };
+
 export const collectV1Errors = (
   sanitizedProject: V1Data,
   errorCollector: ErrorCollector

--- a/packages/project/src/utils/v1-utils.ts
+++ b/packages/project/src/utils/v1-utils.ts
@@ -161,15 +161,15 @@ const checkEventDates = (
 /**
  * The very first crop year on a field is subject to a problem where any fertilizer or tillage events
  * that occur in the calendar year PRIOR to the crop year (like fall fertilizer) will cause the import
- * code to throw because there doesn't yet exist a crop year to assign the event to.
+ * code to throw because there doesn't exist a crop in the corresponding year to assign the event to.
  * We therefore notify the user of the problematic event and remove it from the import.
  *
- * @param crop The crop for which we are detecting edge-case date problems.
- * @param fieldName The name of the field in which this error was encountered.
- * @param earliestCropYear The year of the earliest crop year that appears on this field.
- * @param errorCollector The error collector collecting all errors for this import.
+ * @param crop The crop for which we are looking for edge-case event date problems.
+ * @param fieldName The name of the field currently being checked.
+ * @param earliestCropYear The year of the earliest crop year that appears in this field.
+ * @param errorCollector The error collector aggregating all errors for this import file.
  *
- * @returns The V1Crop with offending events removed.
+ * @returns The original crop but with offending events removed.
  */
 const checkFertilizerTillageDateEdgeCase = (
   crop: V1Crop,


### PR DESCRIPTION
#1173141583

This PR updates the utility method that checks a v1 spec for detectable issues pre-import to detect the edge case in which a fertilizer or tillage event has a calendar year that is prior to the FIRST crop year in a field.  The import code throws because it has no corresponding year to attach the event to.  (Since SoilMetrics deals in calendar years, their API actually rejects the GGIT run if there is an event with a year in date that doesn't match the crop's date year, which I confirmed experimentally and am just noting here for the curious around why we HAVE to move crop events to their corresponding calendar year in the first place.)

The code that attempts to move these events only does so for fertilizer and tillage events, which is why they are singled out. 

This case had not occurred before until we were trying to deal with the Truterra files, wherein some of the fields' first crop year has falltime fertilizer events for the spring's crop and import code throws.

To finish the project, one would need to import the spec, fill out the rest of the sheet (manually or using smart defaults) and then finally manually enter these events that had been omitted, on the crop year corresponding to the calendar year of the event.