### PR TITLE
allow specifying json extensions in eslint

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -102,7 +102,7 @@ module.exports = {
     'one-var': 0,
     'no-underscore-dangle': 0,
     'import/no-cycle': [0], // todo look into enabling this
-    'import/extensions': ['error', 'never', { ts: 'never' }],
+    'import/extensions': ['error', 'never', { ts: 'never', json: 'always' }],
     'import/order': [
       'error',
       {
@@ -201,7 +201,11 @@ module.exports = {
         'require-await': 'off',
         '@typescript-eslint/require-await': 'error',
         'import/first': 0,
-        'import/extensions': ['error', 'never', { ts: 'never' }],
+        'import/extensions': [
+          'error',
+          'never',
+          { ts: 'never', json: 'always' },
+        ],
         '@typescript-eslint/consistent-type-imports': 'warn',
         '@typescript-eslint/member-ordering': 'warn',
         '@typescript-eslint/consistent-type-definitions': [


### PR DESCRIPTION
Currently imports are disallowed using the .json extension in import/require statements. This changes that to force using it (required to play nicely with our tsconfig).

```ts
import * as nccrArtifact from '@nori-dot-com/contracts/build/contracts/NCCR_V0.json'; // previously an eslint error, but no error with this change
import * as nccrArtifact from '@nori-dot-com/contracts/build/contracts/NCCR_V0'; // ts error Cannot find module '@nori-dot-com/contracts/build/contracts/NCCR_V0' or its corresponding type declarations
```