### PR TITLE
Add `authenticationError:missingRole` to errors

### DIFF
--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -225,5 +225,8 @@ export const Errors = {
     wrongPassword: {
       message: 'The password is invalid or the user does not have a password',
     },
+    missingRole: {
+      message: 'The user does not have the required admin role.',
+    },
   },
 };


### PR DESCRIPTION
standard error to use when admin user doesn't have the right role