### PR TITLE
Fix version on example project spec

### DIFF
--- a/packages/project/src/example/example.json
+++ b/packages/project/src/example/example.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "3.0.0",
   "fields": [
     {
       "fieldName": "zyt0f1mnasi",


### PR DESCRIPTION
`example.json` is a V3 formatted data spec, but the version was reading "0.1.0", leading to issues with importing this (since our import infrastructure has to know which version it's digesting)

Sean was running into that issue [here](https://norinauts.slack.com/archives/CNPGM16BC/p1640323673079500).