### PR TITLE
add strict-boolean-expressions eslint rule

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -4,13 +4,6 @@ const allExtensions = jsExtensions.concat(tsExtensions);
 
 module.exports = {
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
@@ -26,7 +19,6 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   plugins: [
-    '@typescript-eslint',
     'import',
     'sort-imports-es6-autofix',
     'require-path-exists',
@@ -52,12 +44,6 @@ module.exports = {
     },
   },
   rules: {
-    'react/function-component-definition': [
-      'warn',
-      {
-        namedComponents: ['function-declaration', 'arrow-function'],
-      },
-    ],
     camelcase: ['warn', { allow: ['__'] }],
     'mui-unused-classes/unused-classes': 'warn',
     '@next/next/no-html-link-for-pages': 0, // we must manually override this in each next app with a custom pages dir
@@ -204,6 +190,7 @@ module.exports = {
     },
     {
       files: ['**/*.ts', '**/*.tsx'],
+      plugins: ['@typescript-eslint', 'mui-unused-classes'],
       extends: [
         'plugin:import/errors',
         'plugin:@typescript-eslint/recommended',
@@ -211,6 +198,19 @@ module.exports = {
         'plugin:prettier/recommended',
       ],
       rules: {
+        '@typescript-eslint/strict-boolean-expressions': [
+          'warn',
+          {
+            allowString: false,
+            allowNumber: false,
+            allowNullableObject: false,
+            allowNullableBoolean: false,
+            allowNullableString: false,
+            allowNullableNumber: false,
+            allowAny: false,
+            allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: true,
+          },
+        ],
         'no-shadow': 'off', // replaced by ts-eslint rule below
         '@typescript-eslint/no-shadow': 'error',
         // 'id-denylist': ['error', 'FC', 'React.FC', 'React.FunctionComponent'],


### PR DESCRIPTION
[Rule definition](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md)

Catches bugs like the following

![image](https://user-images.githubusercontent.com/18407013/158668568-aa028d96-818d-438c-82af-af6d035a54b6.png)
