### PR TITLE
Update base ESLint config with rule to use arrow functions for react components

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -169,6 +169,9 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     'react/jsx-fragments': [1, 'element'],
+    'react/function-component-definition': [2, {
+      'namedComponents': 'arrow-function',
+    }],
     'relay/generated-flow-types': 0,
     'require-path-exists/exists': [
       2,


### PR DESCRIPTION
I think the ESLint update defaulted to requiring function declaration style for React components, which is not the style we have been using in our codebase so this PR updates the base ESLint to use arrow function definitions.

Not sure if we also want to add any other options as found in the rule options here: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md

because I'm pretty sure this rule will force us to use arrow function components