### PR TITLE
tweak eslint rule to permit peerDependencies to be imported

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -119,7 +119,7 @@ module.exports = {
           {
             devDependencies: true,
             optionalDependencies: true,
-            peerDependencies: true,
+            peerDependencies: false,
           },
         ],
 


### PR DESCRIPTION
This change means eslint will not warn when an import is found that imports from a peer dependency