### PR TITLE
[NO-1752] Adds net quantification calculation algo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ dist
 coverage
 
 storybook-static
+
+.DS_Store

--- a/packages/quantification/src/__tests__/net-quantification.test.ts
+++ b/packages/quantification/src/__tests__/net-quantification.test.ts
@@ -1,0 +1,140 @@
+import { getNetQuantificationProjection } from '../net-quantification';
+
+/**
+ * If you'd like to see the output from the algorithm, add `console` as the second
+ * parameter to `getNetQuantificationProjection`
+ */
+
+it('should return a total of 18 NRT', () => {
+  const testData = [
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': -30,
+        '2015': 10,
+        '2017': 9,
+        '2014': 0,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': 10,
+        '2017': 9,
+        '2018': 0,
+        '2015': 10,
+      },
+    },
+  ];
+
+  expect(getNetQuantificationProjection(testData)).toStrictEqual([
+    {
+      '2014': 0,
+      '2015': 0,
+      '2016': 0,
+      '2017': 0,
+      '2018': 0,
+    },
+    {
+      '2014': 0,
+      '2015': 10,
+      '2016': 0,
+      '2017': 8,
+      '2018': 0,
+    },
+  ]);
+});
+
+it('should handle a single year', () => {
+  const testData = [
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': 5,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': 10,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': 15,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': -20,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': 2,
+      },
+    },
+  ];
+
+  expect(getNetQuantificationProjection(testData)).toStrictEqual([
+    {
+      '2016': 0,
+    },
+    {
+      '2016': 0,
+    },
+    {
+      '2016': 12,
+    },
+    {
+      '2016': 0,
+    },
+    {
+      '2016': 0,
+    },
+  ]);
+});
+
+it('should persist a negative amount in the column it originated from', () => {
+  const testData = [
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': 0,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': -50,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': -40,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': -20,
+      },
+    },
+    {
+      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+        '2016': 0,
+      },
+    },
+  ];
+
+  expect(getNetQuantificationProjection(testData)).toStrictEqual([
+    {
+      '2016': 0,
+    },
+    {
+      '2016': -50,
+    },
+    {
+      '2016': -40,
+    },
+    {
+      '2016': -20,
+    },
+    {
+      '2016': 0,
+    },
+  ]);
+});

--- a/packages/quantification/src/__tests__/net-quantification.test.ts
+++ b/packages/quantification/src/__tests__/net-quantification.test.ts
@@ -4,137 +4,158 @@ import { getNetQuantificationProjection } from '../net-quantification';
  * If you'd like to see the output from the algorithm, add `console` as the second
  * parameter to `getNetQuantificationProjection`
  */
+describe('getNetQuantificationProjection', () => {
+  it('should return a total of 18 NRT', () => {
+    const testData = [
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2016': -30,
+          '2015': 10,
+          '2017': 9,
+          '2014': 0,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2016': 10,
+          '2017': 9,
+          '2018': 0,
+          '2015': 10,
+        },
+      },
+    ];
 
-it('should return a total of 18 NRT', () => {
-  const testData = [
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
-        '2016': -30,
-        '2015': 10,
-        '2017': 9,
+    expect(getNetQuantificationProjection(testData)).toStrictEqual([
+      {
         '2014': 0,
-      },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
-        '2016': 10,
-        '2017': 9,
+        '2015': 0,
+        '2016': 0,
+        '2017': 0,
         '2018': 0,
+      },
+      {
+        '2014': 0,
         '2015': 10,
+        '2016': 0,
+        '2017': 8,
+        '2018': 0,
       },
-    },
-  ];
+    ]);
+  });
 
-  expect(getNetQuantificationProjection(testData)).toStrictEqual([
-    {
-      '2014': 0,
-      '2015': 0,
-      '2016': 0,
-      '2017': 0,
-      '2018': 0,
-    },
-    {
-      '2014': 0,
-      '2015': 10,
-      '2016': 0,
-      '2017': 8,
-      '2018': 0,
-    },
-  ]);
-});
+  it('should handle a single year', () => {
+    const testData = [
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2016': 5,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2016': 10,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2016': 15,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2016': -20,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2016': 2,
+        },
+      },
+    ];
 
-it('should handle a single year', () => {
-  const testData = [
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
-        '2016': 5,
-      },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
-        '2016': 10,
-      },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
-        '2016': 15,
-      },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
-        '2016': -20,
-      },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
-        '2016': 2,
-      },
-    },
-  ];
-
-  expect(getNetQuantificationProjection(testData)).toStrictEqual([
-    {
-      '2016': 0,
-    },
-    {
-      '2016': 0,
-    },
-    {
-      '2016': 12,
-    },
-    {
-      '2016': 0,
-    },
-    {
-      '2016': 0,
-    },
-  ]);
-});
-
-it('should persist a negative amount in the column it originated from', () => {
-  const testData = [
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+    expect(getNetQuantificationProjection(testData)).toStrictEqual([
+      {
         '2016': 0,
       },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+      {
+        '2016': 0,
+      },
+      {
+        '2016': 12,
+      },
+      {
+        '2016': 0,
+      },
+      {
+        '2016': 0,
+      },
+    ]);
+  });
+
+  it('should persist a left-over negative amount in the cell it originated from', () => {
+    const testData = [
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2015': 0,
+          '2016': 0,
+          '2017': 0,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2015': 0,
+          '2016': -50,
+          '2017': 0,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2015': 0,
+          '2016': -40,
+          '2017': 0,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2015': 0,
+          '2016': -20,
+          '2017': 0,
+        },
+      },
+      {
+        somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+          '2015': 0,
+          '2016': 0,
+          '2017': 0,
+        },
+      },
+    ];
+
+    expect(getNetQuantificationProjection(testData)).toStrictEqual([
+      {
+        '2015': 0,
+        '2016': 0,
+        '2017': 0,
+      },
+      {
+        '2015': 0,
         '2016': -50,
+        '2017': 0,
       },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+      {
+        '2015': 0,
         '2016': -40,
+        '2017': 0,
       },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+      {
+        '2015': 0,
         '2016': -20,
+        '2017': 0,
       },
-    },
-    {
-      somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+      {
+        '2015': 0,
         '2016': 0,
+        '2017': 0,
       },
-    },
-  ];
-
-  expect(getNetQuantificationProjection(testData)).toStrictEqual([
-    {
-      '2016': 0,
-    },
-    {
-      '2016': -50,
-    },
-    {
-      '2016': -40,
-    },
-    {
-      '2016': -20,
-    },
-    {
-      '2016': 0,
-    },
-  ]);
+    ]);
+  });
 });

--- a/packages/quantification/src/index.ts
+++ b/packages/quantification/src/index.ts
@@ -1,3 +1,4 @@
 export * from './quantification';
 export * from './json-utils';
 export * from './utils';
+export * from './net-quantification';

--- a/packages/quantification/src/net-quantification.ts
+++ b/packages/quantification/src/net-quantification.ts
@@ -1,0 +1,185 @@
+import type {
+  AnnualTotals,
+  UnadjustedQuantificationSummary,
+} from './quantification';
+
+/**
+ * Calculates the net tonnes removed accounting for years with emissions. Years with emissions (represented
+ * by a negative number) should be reduced to zero and any tonnes removed should be reduced by the emitted
+ * amount.
+ *
+ * Algorithm overview:
+ * 1. Years with negative numbers are set to zero
+ * 2. The amount emitted will be debited from the subsequent years of the same field
+ * 3. Should the amount emitted exceed the amount available from subsequent years, wrap to the
+ * start year and continue to the currently considered year
+ * 4. Should the amount exceed all available tonnes removed from this project, repeat step 1
+ * starting with the currently considered year in the next quantification
+ * 5. Should the negative amount exceed the total tonnes available, the negative amount should
+ * persist in the year it originated
+ *
+ * An example:
+ *
+ * Starting with:
+ * | field | 2015 | 2016 | 2017 |
+ * |-------|------|------|------|
+ * | A     | 10   | -30  | 9    |
+ * | B     | 10   | 10   | 9    |
+ *
+ * 30 left
+ * | field | 2015 | 2016 | 2017 |
+ * |-------|------|------|------|
+ * | A     | 10   | 0    | 9    |
+ * | B     | 10   | 10   | 9    |
+ *
+ * 21 left
+ * | field | 2015 | 2016 | 2017 |
+ * |-------|------|------|------|
+ * | A     | 10   | 0    | 0    |
+ * | B     | 10   | 10   | 9    |
+ *
+ * 11 left
+ * | field | 2015 | 2016 | 2017 |
+ * |-------|------|------|------|
+ * | A     | 0    | 0    | 0    |
+ * | B     | 10   | 10   | 9    |
+ *
+ * 1 left
+ * | field | 2015 | 2016 | 2017 |
+ * |-------|------|------|------|
+ * | A     | 0    | 0    | 0    |
+ * | B     | 10   | 0    | 9    |
+ *
+ * 0
+ * | field | 2015 | 2016 | 2017 |
+ * |-------|------|------|------|
+ * | A     | 0    | 0    | 0    |
+ * | B     | 10   | 0    | 8    |
+ * | final | 10   | 0    | 8    |
+ *
+ */
+export const getNetQuantificationProjection = (
+  quantifications: Pick<
+    UnadjustedQuantificationSummary,
+    'somscAnnualDifferencesBetweenFutureAndBaselineScenarios'
+  >[],
+  logger?: Pick<Console, 'debug' | 'table'>
+): AnnualTotals[] => {
+  const netQuantifications: AnnualTotals[] = quantifications.map(
+    (quantification) => ({
+      ...quantification.somscAnnualDifferencesBetweenFutureAndBaselineScenarios,
+    })
+  );
+
+  // Get the set of years in all quantifications
+  const years = new Set<string>();
+  for (const quantification of netQuantifications) {
+    for (const year of Object.keys(quantification)) {
+      years.add(year);
+    }
+  }
+
+  /**
+   * CAUTION -- years are represented as strings and sorted alphabetically. If for some reason, we
+   * begin supporting years < 1000 or > 9999, we'll need to rework this sort
+   */
+  const yearsOrderedAsc = Array.from(years.values()).sort();
+  logger?.debug('All years:', yearsOrderedAsc);
+
+  // No guarantee that all fields have data for each year, so we need to add zeroes for the missing years
+  for (const quantification of netQuantifications) {
+    for (const year of years) {
+      if (quantification[year] === undefined) {
+        quantification[year] = 0;
+      }
+    }
+  }
+
+  let rowIndex = 0;
+  let colIndex = 0;
+  let debt = 0;
+  while (rowIndex < netQuantifications.length) {
+    while (colIndex < yearsOrderedAsc.length) {
+      const yearIndex = yearsOrderedAsc[colIndex];
+      const value = netQuantifications[rowIndex][yearIndex];
+      logger?.debug(`Visiting [${rowIndex}, ${yearIndex}] = ${value}`);
+
+      if (value < 0) {
+        logger?.debug(`Found negative number (${value}), adding to debt`);
+        debt += value;
+        netQuantifications[rowIndex][yearIndex] = 0;
+      }
+
+      if (debt < 0) {
+        logger?.debug(`Accounting for debt of ${debt}`);
+        // Edge case: if there's only one year, start on the next field, otherwise start on the current
+        let accountingRowIndex =
+          yearsOrderedAsc.length === 1
+            ? rowIndex + (1 % netQuantifications.length)
+            : rowIndex;
+        let accountingColIndex = (colIndex + 1) % years.size;
+        let accountingYearIndex = yearsOrderedAsc[accountingColIndex];
+        while (debt < 0) {
+          const accountingCellValue =
+            netQuantifications[accountingRowIndex][accountingYearIndex];
+
+          logger?.debug(
+            `Accounting visiting [${accountingRowIndex}, ${accountingYearIndex}] = ${accountingCellValue}`
+          );
+
+          // Core logic: the amount to take is the lesser of the absolute value of the debt or the
+          // the amount available
+          const amountAvailable = Math.max(accountingCellValue, 0);
+          const amountToTake = Math.min(amountAvailable, Math.abs(debt));
+          const cellRemainder = accountingCellValue - amountToTake;
+          netQuantifications[accountingRowIndex][accountingYearIndex] =
+            cellRemainder;
+          debt += amountToTake;
+
+          logger?.debug(
+            `Removing ${amountToTake} from [${accountingRowIndex}, ${accountingYearIndex}] = ${cellRemainder}`
+          );
+          logger?.debug(`Debt left: ${debt}`);
+          logger?.table(netQuantifications);
+
+          // Go to the next column
+          accountingColIndex =
+            (accountingColIndex + 1) % yearsOrderedAsc.length;
+          accountingYearIndex = yearsOrderedAsc[accountingColIndex];
+          logger?.debug(`Advancing to next year (col ${accountingYearIndex})`);
+
+          // If we're back to the row's starting year, advance to the next field
+          if (accountingColIndex === colIndex) {
+            accountingRowIndex =
+              (accountingRowIndex + 1) % netQuantifications.length;
+            logger?.debug(
+              `Advancing to next field (row ${accountingRowIndex})`
+            );
+          }
+
+          // If we get back to where we started, we can't account for the debt
+          // Set the cell's value to the remainder, clear the debt and break
+          if (
+            accountingRowIndex === rowIndex &&
+            accountingColIndex === colIndex
+          ) {
+            logger?.debug(
+              `Accounting arrived back to start [${accountingRowIndex}, ${accountingYearIndex}] with debt of ${debt}`
+            );
+            netQuantifications[accountingRowIndex][accountingYearIndex] = debt;
+            debt = 0;
+            break;
+          }
+        }
+      }
+
+      colIndex += 1;
+      logger?.table(netQuantifications);
+    }
+
+    colIndex = 0;
+    rowIndex += 1;
+  }
+
+  return netQuantifications;
+};

--- a/packages/quantification/src/net-quantification.ts
+++ b/packages/quantification/src/net-quantification.ts
@@ -1,3 +1,5 @@
+import { add } from '@nori-dot-com/math';
+
 import type {
   AnnualTotals,
   UnadjustedQuantificationSummary,
@@ -106,7 +108,7 @@ export const getNetQuantificationProjection = (
 
       if (value < 0) {
         logger?.debug(`Found negative number (${value}), adding to debt`);
-        debt += value;
+        debt = add(debt, value);
         netQuantifications[rowIndex][yearIndex] = 0;
       }
 
@@ -134,7 +136,7 @@ export const getNetQuantificationProjection = (
           const cellRemainder = accountingCellValue - amountToTake;
           netQuantifications[accountingRowIndex][accountingYearIndex] =
             cellRemainder;
-          debt += amountToTake;
+          debt = add(debt, amountToTake);
 
           logger?.debug(
             `Removing ${amountToTake} from [${accountingRowIndex}, ${accountingYearIndex}] = ${cellRemainder}`

--- a/packages/quantification/src/quantification.ts
+++ b/packages/quantification/src/quantification.ts
@@ -64,6 +64,11 @@ export interface UnadjustedQuantificationSummary {
   modeledYears: number[];
   grandfatheredTonnesPerYearPerAcreAverage: number;
   methodologyVersion: string;
+  /**
+   * The net carbon removed by year, calculated by the algorithm in
+   * [net-quantification.ts](./net-quantification.ts)
+   */
+  netRemovalsByYear?: AnnualTotals;
 }
 
 const getsomscAnnualDifferencesBetweenFutureAndBaselineScenarios = ({


### PR DESCRIPTION
I think we could use more tests but I'd like to get this PR up for a review and merge. I believe we'll have some issuances soon and I'd like to add those to test this calculation. 

Sample output from the first test:

```
 console.debug
    All years: [ '2014', '2015', '2016', '2017', '2018' ]

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:87:11)

  console.debug
    Visiting [0, 2014] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  10  │ -30  │  9   │  0   │
    │    1    │  0   │  10  │  10  │  9   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [0, 2015] = 10

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  10  │ -30  │  9   │  0   │
    │    1    │  0   │  10  │  10  │  9   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [0, 2016] = -30

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.debug
    Found negative number (-30), adding to debt

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:108:17)

  console.debug
    Accounting for debt of -30

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:114:17)

  console.debug
    Accounting visiting [0, 2017] = 9

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:126:19)

  console.debug
    Removing 9 from [0, 2017] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:139:19)

  console.debug
    Debt left: -21

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:142:19)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  10  │  0   │  0   │  0   │
    │    1    │  0   │  10  │  10  │  9   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:143:19)

  console.debug
    Advancing to next year (col 2018)

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:149:19)

  console.debug
    Accounting visiting [0, 2018] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:126:19)

  console.debug
    Removing 0 from [0, 2018] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:139:19)

  console.debug
    Debt left: -21

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:142:19)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  10  │  0   │  0   │  0   │
    │    1    │  0   │  10  │  10  │  9   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:143:19)

  console.debug
    Advancing to next year (col 2014)

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:149:19)

  console.debug
    Accounting visiting [0, 2014] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:126:19)

  console.debug
    Removing 0 from [0, 2014] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:139:19)

  console.debug
    Debt left: -21

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:142:19)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  10  │  0   │  0   │  0   │
    │    1    │  0   │  10  │  10  │  9   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:143:19)

  console.debug
    Advancing to next year (col 2015)

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:149:19)

  console.debug
    Accounting visiting [0, 2015] = 10

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:126:19)

  console.debug
    Removing 10 from [0, 2015] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:139:19)

  console.debug
    Debt left: -11

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:142:19)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  10  │  9   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:143:19)

  console.debug
    Advancing to next year (col 2016)

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:149:19)

  console.debug
    Advancing to next field (row 1)

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:155:21)

  console.debug
    Accounting visiting [1, 2016] = 10

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:126:19)

  console.debug
    Removing 10 from [1, 2016] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:139:19)

  console.debug
    Debt left: -1

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:142:19)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  9   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:143:19)

  console.debug
    Advancing to next year (col 2017)

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:149:19)

  console.debug
    Accounting visiting [1, 2017] = 9

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:126:19)

  console.debug
    Removing 1 from [1, 2017] = 8

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:139:19)

  console.debug
    Debt left: 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:142:19)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:143:19)

  console.debug
    Advancing to next year (col 2018)

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:149:19)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [0, 2017] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [0, 2018] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [1, 2014] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [1, 2015] = 10

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [1, 2016] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [1, 2017] = 8

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)

  console.debug
    Visiting [1, 2018] = 0

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:105:15)

  console.log
    ┌─────────┬──────┬──────┬──────┬──────┬──────┐
    │ (index) │ 2014 │ 2015 │ 2016 │ 2017 │ 2018 │
    ├─────────┼──────┼──────┼──────┼──────┼──────┤
    │    0    │  0   │  0   │  0   │  0   │  0   │
    │    1    │  0   │  10  │  0   │  8   │  0   │
    └─────────┴──────┴──────┴──────┴──────┴──────┘

      at getNetQuantificationProjection (packages/quantification/src/net-quantification.ts:177:15)
```