### PR TITLE
add chai eslint plugins; add custom waffle rule

### DIFF
--- a/packages/eslint-config-nori/eslint-local-rules/index.js
+++ b/packages/eslint-config-nori/eslint-local-rules/index.js
@@ -1,0 +1,5 @@
+const waffleAsPromised = require('./waffle-as-promised');
+
+module.exports = {
+  'waffle-as-promised': waffleAsPromised,
+};

--- a/packages/eslint-config-nori/eslint-local-rules/waffle-as-promised.js
+++ b/packages/eslint-config-nori/eslint-local-rules/waffle-as-promised.js
@@ -1,0 +1,37 @@
+const findInExpressionTree = require('@fintechstudios/eslint-plugin-chai-as-promised/lib/util/find-in-expression-tree'); // todo try replacing with esquery
+
+const isWaffleAsPromised = (node) => {
+  return node.type === 'MemberExpression' &&
+    ['emit'].includes(node.property.name)
+    ? node.property
+    : undefined;
+};
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Must handle promises returned from waffle-as-promised expressions',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+  },
+  create(context) {
+    return {
+      ExpressionStatement(node) {
+        const [waffleAsPromisedCall] = findInExpressionTree(node.expression, [
+          isWaffleAsPromised,
+        ]);
+        if (waffleAsPromisedCall) {
+          context.report({
+            node: waffleAsPromisedCall,
+            message: 'Events must be handled with await',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -51,6 +51,7 @@ module.exports = {
         'jsdoc',
         'jest',
         'mui-unused-classes',
+        'local-rules',
       ],
       processor: '@graphql-eslint/graphql',
       rules: {

--- a/packages/eslint-config-nori/package.json
+++ b/packages/eslint-config-nori/package.json
@@ -12,7 +12,8 @@
   "files": [
     "index.js",
     "package.json",
-    "rules.js"
+    "rules.js",
+    "eslint-local-rules/index.js"
   ],
   "repository": {
     "type": "git",
@@ -29,6 +30,10 @@
     "react-dom": "~17"
   },
   "devDependencies": {
+    "eslint-plugin-local-rules": "^1.3.0",
+    "@fintechstudios/eslint-plugin-chai-as-promised": "3.1.0",
+    "eslint-plugin-chai-friendly": "^0.7.2",
+    "eslint-plugin-chai-expect": "^3.0.0",
     "eslint-plugin-unicorn": "42.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-import-resolver-typescript": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,6 +795,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@fintechstudios/eslint-plugin-chai-as-promised@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@fintechstudios/eslint-plugin-chai-as-promised/-/eslint-plugin-chai-as-promised-3.1.0.tgz#e890cb914cb581725cdee96e2124c25b8cb3d7ab"
+  integrity sha512-Y3TmITTwc5u8hoW0GWxle1hKiVadDqDHyLQaTv+e+xVDHazn361QIEY9NbWqNsXP0jzrSskpnhkBr++h+PciEw==
+
 "@graphql-eslint/eslint-plugin@^3.10.3":
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.10.3.tgz#5e77f18b18769fe68565a76cc33a094576809b5c"
@@ -4099,6 +4104,16 @@ eslint-module-utils@^2.7.3:
     debug "^3.2.7"
     find-up "^2.1.0"
 
+eslint-plugin-chai-expect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-3.0.0.tgz#812d7384756177b2d424040cb3c20e78606db1b2"
+  integrity sha512-NS0YBcToJl+BRKBSMCwRs/oHJIX67fG5Gvb4tGked+9Wnd1/PzKijd82B2QVKcSSOwRe+pp4RAJ2AULeck4eQw==
+
+eslint-plugin-chai-friendly@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.2.tgz#0ebfbb2c1244f5de2997f3963d155758234f2b0f"
+  integrity sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg==
+
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
@@ -4163,6 +4178,11 @@ eslint-plugin-jsx-a11y@^6.5.1:
     jsx-ast-utils "^3.2.1"
     language-tags "^1.0.5"
     minimatch "^3.0.4"
+
+eslint-plugin-local-rules@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.3.0.tgz#4538aa43eaef2f0a783399d4f98ea367248a704c"
+  integrity sha512-QiiI6ZpWxWaWojkouTcmkjrbVfGy78VfRmvvndNPEY4p+B8gtDDLwgRaUiQXAJtDUJvjzrAauOyhVGKbG1mGLw==
 
 eslint-plugin-mui-unused-classes@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR adds a few eslint plugins to make it easier to prevent some common mistakes in mocha+chai tests

- https://github.com/fintechstudios/eslint-plugin-chai-as-promised
- https://github.com/ihordiachenko/eslint-plugin-chai-friendly

I've also added [eslint-plugin-local-rules](https://www.npmjs.com/package/eslint-plugin-local-rules) which lets us easily define our own custom rules easily. As an example, I've written a custom rule called `waffle-as-promised` which will detect an error when `await expect(...)` is not found when testing `.emit`  which prevents this hard to remember best practice from occurring and causing logical bugs in our tests

```ts

await expect(harness.addCliff(1).to.emit(harness, 'CliffAdded'); // PASSES
expect(await harness.addCliff(1).to.emit(harness, 'CliffAdded'); // FAILS

```

![image](https://user-images.githubusercontent.com/18407013/176955899-af422fcc-cc83-4f02-abb2-199b9d80c3df.png)
