### PR TITLE
Fixes out-of-bounds index access

### DIFF
--- a/packages/quantification/src/__tests__/net-quantification.test.ts
+++ b/packages/quantification/src/__tests__/net-quantification.test.ts
@@ -234,4 +234,25 @@ describe('getNetQuantificationProjection', () => {
       );
     });
   });
+
+  describe('regression cases', () => {
+    it('should not access an index over the row length', () => {
+      const negativeTestData = [
+        {
+          somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+              '2018': 10, '2019': 18, '2020': -5, '2021': 11
+          },
+        },
+        {
+          somscAnnualDifferencesBetweenFutureAndBaselineScenarios: {
+              '2018': -10, '2019': 18, '2020': 5, '2021': 11
+          },
+        },
+      ];
+      expect(getNetQuantificationProjection(negativeTestData)).toStrictEqual([
+        [{ year: '2018', value: 0 }, {year: '2019', value: 18}, {year: '2020', value: 0}, {year: '2021', value: 11}],
+        [{ year: '2018', value: 0 }, {year: '2019', value: 18}, {year: '2020', value: 0}, {year: '2021', value: 11}],
+      ]);
+    })
+  })
 });

--- a/packages/quantification/src/net-quantification.ts
+++ b/packages/quantification/src/net-quantification.ts
@@ -116,7 +116,7 @@ export const getNetQuantificationProjection = (
 
       if (debt < 0) {
         logger?.debug(`Accounting for debt of ${debt}`);
-        let accountingRowIndex = rowIndex + (1 % netQuantifications.length);
+        let accountingRowIndex = (rowIndex + 1) % netQuantifications.length;
         let accountingColIndex = colIndex;
         let accountingYearIndex = yearsOrderedAsc[accountingColIndex];
         while (debt < 0) {


### PR DESCRIPTION
Fixes a dumb error spotted by Dave Raskin where the row counter exceeds the indexes available. Adds a unit test that repro'd this error and verifies the fix. 