### PR TITLE
[NO-2036] Leaves null and undefined values as-is

### DIFF
--- a/packages/quantification/src/__tests__/net-quantification.test.ts
+++ b/packages/quantification/src/__tests__/net-quantification.test.ts
@@ -50,10 +50,8 @@ describe('getNetQuantificationProjection', () => {
         { year: '2015', value: 8 },
         { year: '2016', value: 0 },
         { year: '2017', value: 0 },
-        { year: '2018', value: 0 },
       ],
       [
-        { year: '2014', value: 0 },
         { year: '2015', value: 10 },
         { year: '2016', value: 0 },
         { year: '2017', value: 0 },
@@ -261,6 +259,39 @@ describe('getNetQuantificationProjection', () => {
         { year: '2016', value: 0 },
         { year: '2017', value: 0 },
       ],
+    ]);
+  });
+
+  it('should not return a value for years that are in a other fields', () => {
+    const testData = [
+      {
+        unadjustedGrandfatheredTonnesPerYear: {
+          '2015': {
+            amount: -5,
+          },
+          '2016': {
+            amount: 0,
+          },
+          '2017': {
+            amount: 0,
+          },
+        },
+      },
+      {
+        unadjustedGrandfatheredTonnesPerYear: {
+          '2016': {
+            amount: 10,
+          },
+        },
+      },
+    ];
+    expect(getNetQuantificationProjection(testData)).toStrictEqual([
+      [
+        { year: '2015', value: 0 },
+        { year: '2016', value: 0 },
+        { year: '2017', value: 0 },
+      ],
+      [{ year: '2016', value: 5 }],
     ]);
   });
 

--- a/packages/quantification/src/__tests__/net-quantification.test.ts
+++ b/packages/quantification/src/__tests__/net-quantification.test.ts
@@ -262,7 +262,7 @@ describe('getNetQuantificationProjection', () => {
     ]);
   });
 
-  it('should not return a value for years that are in a other fields', () => {
+  it('should not return a value for years that are only in other fields', () => {
     const testData = [
       {
         unadjustedGrandfatheredTonnesPerYear: {

--- a/packages/quantification/src/__tests__/test-fixtures/net-quantification-knuth-result.json
+++ b/packages/quantification/src/__tests__/test-fixtures/net-quantification-knuth-result.json
@@ -2,11 +2,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -46,11 +46,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -90,11 +90,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -112,7 +112,7 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
@@ -134,11 +134,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -178,11 +178,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -200,11 +200,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -222,7 +222,7 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
@@ -244,7 +244,7 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
@@ -266,11 +266,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -288,11 +288,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",
@@ -332,7 +332,7 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
@@ -354,11 +354,11 @@
   [
     {
       "year": "2016",
-      "value": 0
+      "value": null
     },
     {
       "year": "2017",
-      "value": 0
+      "value": null
     },
     {
       "year": "2018",

--- a/packages/quantification/src/net-quantification.ts
+++ b/packages/quantification/src/net-quantification.ts
@@ -95,15 +95,6 @@ export const getNetQuantificationProjection = (
   const yearsOrderedAsc = Array.from(years.values()).sort();
   logger?.debug('All years:', yearsOrderedAsc);
 
-  // No guarantee that all fields have data for each year, so we need to add zeroes for the missing years
-  for (const quantification of netQuantifications) {
-    for (const year of years) {
-      if (quantification[year] === undefined || quantification[year] === null) {
-        quantification[year] = 0;
-      }
-    }
-  }
-
   let rowIndex = 0;
   let colIndex = 0;
   let debt = 0;
@@ -129,24 +120,29 @@ export const getNetQuantificationProjection = (
           const accountingCellValue =
             netQuantifications[accountingRowIndex][accountingYearIndex];
 
-          logger?.debug(
-            `Accounting visiting [${accountingRowIndex}, ${accountingYearIndex}] = ${accountingCellValue}`
-          );
+          if (
+            accountingCellValue !== null &&
+            accountingCellValue !== undefined
+          ) {
+            logger?.debug(
+              `Accounting visiting [${accountingRowIndex}, ${accountingYearIndex}] = ${accountingCellValue}`
+            );
 
-          // Core logic: the amount to take is the lesser of the absolute value of the debt or the
-          // the amount available
-          const amountAvailable = Math.max(accountingCellValue, 0);
-          const amountToTake = Math.min(amountAvailable, Math.abs(debt));
-          const cellRemainder = subtract(accountingCellValue, amountToTake);
-          netQuantifications[accountingRowIndex][accountingYearIndex] =
-            cellRemainder;
-          debt = add(debt, amountToTake);
+            // Core logic: the amount to take is the lesser of the absolute value of the debt or the
+            // the amount available
+            const amountAvailable = Math.max(accountingCellValue, 0);
+            const amountToTake = Math.min(amountAvailable, Math.abs(debt));
+            const cellRemainder = subtract(accountingCellValue, amountToTake);
+            netQuantifications[accountingRowIndex][accountingYearIndex] =
+              cellRemainder;
+            debt = add(debt, amountToTake);
 
-          logger?.debug(
-            `Removing ${amountToTake} from [${accountingRowIndex}, ${accountingYearIndex}] = ${cellRemainder}`
-          );
-          logger?.debug(`Debt left: ${debt}`);
-          logger?.table(netQuantifications);
+            logger?.debug(
+              `Removing ${amountToTake} from [${accountingRowIndex}, ${accountingYearIndex}] = ${cellRemainder}`
+            );
+            logger?.debug(`Debt left: ${debt}`);
+            logger?.table(netQuantifications);
+          }
 
           // Go to the next row
           accountingRowIndex =


### PR DESCRIPTION
Quantification previously took the set of all years and made them equal to zero for every quantification in the field set. This change leaves the null or undefined values as-is, and returns null or leaves them out