### PR TITLE
Add `parcelError:hasMintedRemovals`

### DIFF
--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -271,5 +271,8 @@ export const Errors = {
     alreadyHasIssuance: {
       message: 'Parcel already has an issuance created',
     },
+    hasMintedRemovals: {
+      message: 'Parcel already has at least one removal minted to chain',
+    },
   },
 };


### PR DESCRIPTION
Adds an error to indicate that a parcel can't have its NRT approval revoked if it already has minted (or pending mint) removals