### PR TITLE
Add error for test env recaptcha

### DIFF
--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -271,6 +271,10 @@ export const Errors = {
     invalidPhoneNumber: {
       message: 'Enter a valid phone number.',
     },
+    captchaCheckFailed: {
+      message:
+        'A recaptcha error occurred.  You are most likely seeing this because you are trying to log into an mfa-enabled account on a test environment with a real phone number. Either disable MFA or use one of the test phone numbers in the Firebase Console.',
+    },
   },
   miscError: {
     unexpectedError: 'An unexpected error occurred',


### PR DESCRIPTION
Covering MFA with cypress tests required disabling recaptcha on the test env.  However, this means that anyone using the app locally will be unable to sign in normally with MFA.  

Either they will need to have one of the test phone numbers from the firebase console associated with their account, or they will need to remove MFA from the console in order to log in.

This error message should *only* surface for users on the 'test' environment.