### PR TITLE
Add project name to spec

### DIFF
--- a/packages/project/CHANGELOG.md
+++ b/packages/project/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.0.7 (October 31, 2022)
+* added `Project.projectName`
+
 # v4.0.6 (October 27, 2022)
 * Added `Project.supplierId`
 * Added `CropYear.dataSourceType` enum to permit the supplier to specify whether the CropYear's data is source from actual grower past data or project future practice data.

--- a/packages/project/docs/interfaces/v3_specification.AnnualCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.AnnualCrop.md
@@ -85,7 +85,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -109,7 +109,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v3-specification.ts:1253](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1253)
+[v3-specification.ts:1253](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1253)
 
 ___
 
@@ -141,7 +141,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -177,7 +177,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -208,7 +208,7 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L837)
 
 ___
 
@@ -238,7 +238,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -273,7 +273,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -299,7 +299,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -337,7 +337,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -367,7 +367,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -399,7 +399,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -425,4 +425,4 @@ must specify one of the allowed crop types if you are specifying an annual crop
 
 #### Defined in
 
-[v3-specification.ts:1238](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1238)
+[v3-specification.ts:1238](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1238)

--- a/packages/project/docs/interfaces/v3_specification.AnnualCropHarvestEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.AnnualCropHarvestEvent.md
@@ -79,7 +79,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -115,7 +115,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1369)
+[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1369)
 
 ___
 
@@ -167,7 +167,7 @@ Crop residue removed.
 
 #### Defined in
 
-[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1397)
+[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1397)
 
 ___
 
@@ -193,7 +193,7 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v3-specification.ts:1431](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1431)
+[v3-specification.ts:1431](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1431)
 
 ___
 
@@ -219,4 +219,4 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v3-specification.ts:1446](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1446)
+[v3-specification.ts:1446](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1446)

--- a/packages/project/docs/interfaces/v3_specification.BurningEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.BurningEvent.md
@@ -46,4 +46,4 @@ The type of burning, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:1947](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1947)
+[v3-specification.ts:1947](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1947)

--- a/packages/project/docs/interfaces/v3_specification.CoverCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.CoverCrop.md
@@ -81,7 +81,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -105,7 +105,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v3-specification.ts:1201](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1201)
+[v3-specification.ts:1201](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1201)
 
 ___
 
@@ -137,7 +137,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -173,7 +173,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -203,7 +203,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -238,7 +238,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -264,7 +264,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -302,7 +302,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -332,7 +332,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -364,7 +364,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -386,4 +386,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1186](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1186)
+[v3-specification.ts:1186](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1186)

--- a/packages/project/docs/interfaces/v3_specification.CropEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.CropEvent.md
@@ -73,4 +73,4 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)

--- a/packages/project/docs/interfaces/v3_specification.CropEventRange.md
+++ b/packages/project/docs/interfaces/v3_specification.CropEventRange.md
@@ -50,7 +50,7 @@ The last date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 a
 
 #### Defined in
 
-[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1333)
+[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1333)
 
 ___
 
@@ -74,4 +74,4 @@ The first date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 
 
 #### Defined in
 
-[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1320)
+[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1320)

--- a/packages/project/docs/interfaces/v3_specification.CropEvents.md
+++ b/packages/project/docs/interfaces/v3_specification.CropEvents.md
@@ -94,7 +94,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -122,7 +122,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -154,7 +154,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -180,7 +180,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -211,7 +211,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -245,7 +245,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -273,4 +273,4 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L891)

--- a/packages/project/docs/interfaces/v3_specification.CropManagementEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.CropManagementEvent.md
@@ -75,7 +75,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -107,7 +107,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1369)
+[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1369)
 
 ___
 
@@ -155,4 +155,4 @@ Crop residue removed.
 
 #### Defined in
 
-[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1397)
+[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1397)

--- a/packages/project/docs/interfaces/v3_specification.CropYear.md
+++ b/packages/project/docs/interfaces/v3_specification.CropYear.md
@@ -70,7 +70,7 @@ Due to a limitation at COMET farm, the maximum number of crops per [plantingYear
 
 #### Defined in
 
-[v3-specification.ts:752](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L752)
+[v3-specification.ts:752](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L752)
 
 ___
 
@@ -98,4 +98,4 @@ The planting year that the herein defined [crops](#crops) property is associated
 
 #### Defined in
 
-[v3-specification.ts:717](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L717)
+[v3-specification.ts:717](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L717)

--- a/packages/project/docs/interfaces/v3_specification.FertilizerEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.FertilizerEvent.md
@@ -75,7 +75,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -99,7 +99,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v3-specification.ts:1611](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1611)
+[v3-specification.ts:1611](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1611)
 
 ___
 
@@ -123,7 +123,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1583](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1583)
+[v3-specification.ts:1583](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1583)
 
 ___
 
@@ -149,4 +149,4 @@ Note that the fertilizer type does not currently impact quantification as it onl
 
 #### Defined in
 
-[v3-specification.ts:1598](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1598)
+[v3-specification.ts:1598](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1598)

--- a/packages/project/docs/interfaces/v3_specification.Field.md
+++ b/packages/project/docs/interfaces/v3_specification.Field.md
@@ -72,7 +72,7 @@ during import (note: when acres is defined as null in an import file it will ins
 
 #### Defined in
 
-[v3-specification.ts:651](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L651)
+[v3-specification.ts:651](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L651)
 
 ___
 
@@ -99,7 +99,7 @@ A list of crop management details grouped by the crop planting year.
 
 #### Defined in
 
-[v3-specification.ts:686](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L686)
+[v3-specification.ts:686](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L686)
 
 ___
 
@@ -128,7 +128,7 @@ The name of the field.
 
 #### Defined in
 
-[v3-specification.ts:638](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L638)
+[v3-specification.ts:638](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L638)
 
 ___
 
@@ -154,7 +154,7 @@ For additional guidance and limitation of boundary files, [refer to the FAQ here
 
 #### Defined in
 
-[v3-specification.ts:668](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L668)
+[v3-specification.ts:668](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L668)
 
 ___
 
@@ -201,7 +201,7 @@ during import (note: when historicLandManagement is defined as null in an import
 
 #### Defined in
 
-[v3-specification.ts:617](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L617)
+[v3-specification.ts:617](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L617)
 
 ___
 
@@ -227,4 +227,4 @@ For more information on how to select a start year see [here](https://go.nori.co
 
 #### Defined in
 
-[v3-specification.ts:583](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L583)
+[v3-specification.ts:583](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L583)

--- a/packages/project/docs/interfaces/v3_specification.GrazingEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.GrazingEvent.md
@@ -58,7 +58,7 @@ The last date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 a
 
 #### Defined in
 
-[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1333)
+[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1333)
 
 ___
 
@@ -96,7 +96,7 @@ Zero and one are equivalent and indicate continuous grazing.
 
 #### Defined in
 
-[v3-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1901)
+[v3-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1901)
 
 ___
 
@@ -124,7 +124,7 @@ The first date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 
 
 #### Defined in
 
-[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1320)
+[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1320)
 
 ___
 
@@ -152,4 +152,4 @@ The percentage of forage consumed by the animals per rest period days.
 
 #### Defined in
 
-[v3-specification.ts:1915](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1915)
+[v3-specification.ts:1915](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1915)

--- a/packages/project/docs/interfaces/v3_specification.HarvestableCropEvents.md
+++ b/packages/project/docs/interfaces/v3_specification.HarvestableCropEvents.md
@@ -62,4 +62,4 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L837)

--- a/packages/project/docs/interfaces/v3_specification.HistoricCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v3_specification.HistoricCRPLandManagement.md
@@ -68,7 +68,7 @@ Whether the field participated in CRP or not.
 
 #### Defined in
 
-[v3-specification.ts:418](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L418)
+[v3-specification.ts:418](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L418)
 
 ___
 
@@ -96,7 +96,7 @@ The CRP end year
 
 #### Defined in
 
-[v3-specification.ts:463](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L463)
+[v3-specification.ts:463](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L463)
 
 ___
 
@@ -124,7 +124,7 @@ The CRP start year
 
 #### Defined in
 
-[v3-specification.ts:449](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L449)
+[v3-specification.ts:449](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L449)
 
 ___
 
@@ -152,7 +152,7 @@ The type of CRP the field participated in. Only applicable if [crp](#crp) is set
 
 #### Defined in
 
-[v3-specification.ts:435](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L435)
+[v3-specification.ts:435](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L435)
 
 ___
 
@@ -172,7 +172,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v3-specification.ts:509](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L509)
+[v3-specification.ts:509](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L509)
 
 ___
 
@@ -190,7 +190,7 @@ How was the field managed after tillage
 
 #### Defined in
 
-[v3-specification.ts:529](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L529)
+[v3-specification.ts:529](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L529)
 
 ___
 
@@ -210,7 +210,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v3-specification.ts:476](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L476)
+[v3-specification.ts:476](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L476)
 
 ___
 
@@ -228,7 +228,7 @@ How was the field tilled before the field entered into CRP
 
 #### Defined in
 
-[v3-specification.ts:496](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L496)
+[v3-specification.ts:496](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L496)
 
 ___
 
@@ -276,4 +276,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L296)
+[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L296)

--- a/packages/project/docs/interfaces/v3_specification.HistoricLandManagement.md
+++ b/packages/project/docs/interfaces/v3_specification.HistoricLandManagement.md
@@ -68,4 +68,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L296)
+[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L296)

--- a/packages/project/docs/interfaces/v3_specification.HistoricNonCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v3_specification.HistoricNonCRPLandManagement.md
@@ -54,7 +54,7 @@ Whether the field participated in CRP or not.
 
 #### Defined in
 
-[v3-specification.ts:331](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L331)
+[v3-specification.ts:331](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L331)
 
 ___
 
@@ -102,7 +102,7 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L296)
+[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L296)
 
 ___
 
@@ -138,7 +138,7 @@ The type of soil or crop disturbance events used on the field between 1980 and 2
 
 #### Defined in
 
-[v3-specification.ts:354](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L354)
+[v3-specification.ts:354](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L354)
 
 ___
 
@@ -156,4 +156,4 @@ A description of how the land was managed between 1980 and 2000.
 
 #### Defined in
 
-[v3-specification.ts:368](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L368)
+[v3-specification.ts:368](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L368)

--- a/packages/project/docs/interfaces/v3_specification.IrrigationEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.IrrigationEvent.md
@@ -71,7 +71,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -95,4 +95,4 @@ The irrigation volume in inches. If volume is 0, simply do not define an irrigat
 
 #### Defined in
 
-[v3-specification.ts:1806](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1806)
+[v3-specification.ts:1806](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1806)

--- a/packages/project/docs/interfaces/v3_specification.LimingEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.LimingEvent.md
@@ -46,7 +46,7 @@ The date that the liming occurred. Currently, liming dates do not impact quantif
 
 #### Defined in
 
-[v3-specification.ts:1861](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1861)
+[v3-specification.ts:1861](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1861)
 
 ___
 
@@ -70,7 +70,7 @@ The liming amount (in tons per acre).
 
 #### Defined in
 
-[v3-specification.ts:1848](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1848)
+[v3-specification.ts:1848](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1848)
 
 ___
 
@@ -90,4 +90,4 @@ The liming type.
 
 #### Defined in
 
-[v3-specification.ts:1835](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1835)
+[v3-specification.ts:1835](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1835)

--- a/packages/project/docs/interfaces/v3_specification.OrchardOrVineyardCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.OrchardOrVineyardCrop.md
@@ -88,7 +88,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -120,7 +120,7 @@ Note: if a crop ever changes classifications during the lifetime of the field (i
 
 #### Defined in
 
-[v3-specification.ts:1071](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1071)
+[v3-specification.ts:1071](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1071)
 
 ___
 
@@ -152,7 +152,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -188,7 +188,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -219,7 +219,7 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L837)
 
 ___
 
@@ -249,7 +249,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -284,7 +284,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -310,7 +310,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -348,7 +348,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -378,7 +378,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -406,7 +406,7 @@ Indicates if the crop was pruned.
 
 #### Defined in
 
-[v3-specification.ts:1089](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1089)
+[v3-specification.ts:1089](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1089)
 
 ___
 
@@ -434,7 +434,7 @@ Indicates if the crop was renewed or cleared.
 
 #### Defined in
 
-[v3-specification.ts:1106](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1106)
+[v3-specification.ts:1106](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1106)
 
 ___
 
@@ -466,7 +466,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -488,4 +488,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1050](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1050)
+[v3-specification.ts:1050](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1050)

--- a/packages/project/docs/interfaces/v3_specification.OrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.OrganicMatterEvent.md
@@ -65,7 +65,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1720)
+[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1720)
 
 ___
 
@@ -99,7 +99,7 @@ during import
 
 #### Defined in
 
-[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1759)
+[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1759)
 
 ___
 
@@ -144,7 +144,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -168,7 +168,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1706)
+[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1706)
 
 ___
 
@@ -204,7 +204,7 @@ during import (explicitly specify null if you are unsure what the value is)
 
 #### Defined in
 
-[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1777)
+[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1777)
 
 ___
 
@@ -242,4 +242,4 @@ during import (when defined as undefined, a default value will be assigned)
 
 #### Defined in
 
-[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1740)
+[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1740)

--- a/packages/project/docs/interfaces/v3_specification.PerennialCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.PerennialCrop.md
@@ -84,7 +84,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -108,7 +108,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v3-specification.ts:1155](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1155)
+[v3-specification.ts:1155](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1155)
 
 ___
 
@@ -140,7 +140,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -176,7 +176,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -207,7 +207,7 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L837)
 
 ___
 
@@ -237,7 +237,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -272,7 +272,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -298,7 +298,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -336,7 +336,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -366,7 +366,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -398,7 +398,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -420,4 +420,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1140](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1140)
+[v3-specification.ts:1140](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1140)

--- a/packages/project/docs/interfaces/v3_specification.PlantedCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.PlantedCrop.md
@@ -53,7 +53,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -79,4 +79,4 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L799)

--- a/packages/project/docs/interfaces/v3_specification.Project.md
+++ b/packages/project/docs/interfaces/v3_specification.Project.md
@@ -70,7 +70,7 @@ An array of fields defining annual crop management practices.
 
 #### Defined in
 
-[v3-specification.ts:254](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L254)
+[v3-specification.ts:254](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L254)
 
 ___
 
@@ -97,4 +97,4 @@ The specification version. This information is used to determine the logic Nori 
 
 #### Defined in
 
-[v3-specification.ts:228](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L228)
+[v3-specification.ts:228](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L228)

--- a/packages/project/docs/interfaces/v3_specification.SlurryOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.SlurryOrganicMatterEvent.md
@@ -67,7 +67,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1720)
+[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1720)
 
 ___
 
@@ -105,7 +105,7 @@ during import
 
 #### Defined in
 
-[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1759)
+[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1759)
 
 ___
 
@@ -150,7 +150,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -178,7 +178,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1706)
+[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1706)
 
 ___
 
@@ -218,7 +218,7 @@ during import (explicitly specify null if you are unsure what the value is)
 
 #### Defined in
 
-[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1777)
+[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1777)
 
 ___
 
@@ -260,7 +260,7 @@ during import (when defined as undefined, a default value will be assigned)
 
 #### Defined in
 
-[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1740)
+[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1740)
 
 ___
 
@@ -280,4 +280,4 @@ The organic matter or manure classification type.
 
 #### Defined in
 
-[v3-specification.ts:1673](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1673)
+[v3-specification.ts:1673](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1673)

--- a/packages/project/docs/interfaces/v3_specification.SoilOrCropDisturbanceEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.SoilOrCropDisturbanceEvent.md
@@ -72,7 +72,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -102,7 +102,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1479)
+[v3-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1479)
 
 ___
 
@@ -204,4 +204,4 @@ You can find a list of common equivalents [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1552)
+[v3-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1552)

--- a/packages/project/docs/interfaces/v3_specification.SolidOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.SolidOrganicMatterEvent.md
@@ -67,7 +67,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1720)
+[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1720)
 
 ___
 
@@ -105,7 +105,7 @@ during import
 
 #### Defined in
 
-[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1759)
+[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1759)
 
 ___
 
@@ -150,7 +150,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -178,7 +178,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1706)
+[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1706)
 
 ___
 
@@ -218,7 +218,7 @@ during import (explicitly specify null if you are unsure what the value is)
 
 #### Defined in
 
-[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1777)
+[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1777)
 
 ___
 
@@ -260,7 +260,7 @@ during import (when defined as undefined, a default value will be assigned)
 
 #### Defined in
 
-[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1740)
+[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1740)
 
 ___
 
@@ -280,4 +280,4 @@ The solid/dry organic matter or manure classification type.
 
 #### Defined in
 
-[v3-specification.ts:1642](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L1642)
+[v3-specification.ts:1642](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L1642)

--- a/packages/project/docs/interfaces/v4_specification.Address.md
+++ b/packages/project/docs/interfaces/v4_specification.Address.md
@@ -47,7 +47,7 @@ US-ND
 
 #### Defined in
 
-[v4-specification.ts:531](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L531)
+[v4-specification.ts:537](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L537)
 
 ___
 
@@ -69,7 +69,7 @@ In the US use FIPS code: https://www.nrcs.usda.gov/wps/portal/nrcs/detail/nation
 
 #### Defined in
 
-[v4-specification.ts:541](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L541)
+[v4-specification.ts:547](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L547)
 
 ___
 
@@ -89,7 +89,7 @@ Fargo
 
 #### Defined in
 
-[v4-specification.ts:521](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L521)
+[v4-specification.ts:527](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L527)
 
 ___
 
@@ -111,7 +111,7 @@ US
 
 #### Defined in
 
-[v4-specification.ts:551](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L551)
+[v4-specification.ts:557](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L557)
 
 ___
 
@@ -137,7 +137,7 @@ PO Box 56789
 
 #### Defined in
 
-[v4-specification.ts:503](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L503)
+[v4-specification.ts:509](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L509)
 
 ___
 
@@ -163,4 +163,4 @@ Station 99
 
 #### Defined in
 
-[v4-specification.ts:513](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L513)
+[v4-specification.ts:519](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L519)

--- a/packages/project/docs/interfaces/v4_specification.AnnualCrop.md
+++ b/packages/project/docs/interfaces/v4_specification.AnnualCrop.md
@@ -92,7 +92,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1546](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1546)
+[v4-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1552)
 
 ___
 
@@ -116,7 +116,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v4-specification.ts:1807](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1807)
+[v4-specification.ts:1813](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1813)
 
 ___
 
@@ -164,7 +164,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1596](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1596)
+[v4-specification.ts:1602](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1602)
 
 ___
 
@@ -196,7 +196,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1294](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1294)
+[v4-specification.ts:1300](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1300)
 
 ___
 
@@ -238,7 +238,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1427](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1427)
+[v4-specification.ts:1433](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1433)
 
 ___
 
@@ -283,7 +283,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1521](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1521)
+[v4-specification.ts:1527](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1527)
 
 ___
 
@@ -324,7 +324,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1618](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1618)
+[v4-specification.ts:1624](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1624)
 
 ___
 
@@ -352,7 +352,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1310](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1310)
+[v4-specification.ts:1316](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1316)
 
 ___
 
@@ -392,7 +392,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1473](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1473)
+[v4-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1479)
 
 ___
 
@@ -437,7 +437,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1497)
+[v4-specification.ts:1503](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1503)
 
 ___
 
@@ -463,7 +463,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:1272](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1272)
+[v4-specification.ts:1278](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1278)
 
 ___
 
@@ -509,7 +509,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1452](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1452)
+[v4-specification.ts:1458](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1458)
 
 ___
 
@@ -559,7 +559,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1380](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1380)
+[v4-specification.ts:1386](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1386)
 
 ___
 
@@ -607,7 +607,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1571](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1571)
+[v4-specification.ts:1577](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1577)
 
 ___
 
@@ -649,7 +649,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1404](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1404)
+[v4-specification.ts:1410](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1410)
 
 ___
 
@@ -675,4 +675,4 @@ must specify one of the allowed crop types if you are specifying an annual crop
 
 #### Defined in
 
-[v4-specification.ts:1792](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1792)
+[v4-specification.ts:1798](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1798)

--- a/packages/project/docs/interfaces/v4_specification.BurningEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.BurningEvent.md
@@ -63,7 +63,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -89,7 +89,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -117,7 +117,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -149,4 +149,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)

--- a/packages/project/docs/interfaces/v4_specification.ClearingAndRenewalEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.ClearingAndRenewalEvent.md
@@ -65,7 +65,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -91,7 +91,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -119,7 +119,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -147,7 +147,7 @@ Percentage or orchard or vinyard that was cleared and renewed.
 
 #### Defined in
 
-[v4-specification.ts:2496](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2496)
+[v4-specification.ts:2502](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2502)
 
 ___
 
@@ -179,4 +179,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)

--- a/packages/project/docs/interfaces/v4_specification.ContactInfo.md
+++ b/packages/project/docs/interfaces/v4_specification.ContactInfo.md
@@ -34,7 +34,7 @@ email
 
 #### Defined in
 
-[v4-specification.ts:476](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L476)
+[v4-specification.ts:482](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L482)
 
 ___
 
@@ -48,7 +48,7 @@ The project's primary contract person.  Provided to the verified.
 
 #### Defined in
 
-[v4-specification.ts:464](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L464)
+[v4-specification.ts:470](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L470)
 
 ___
 
@@ -62,4 +62,4 @@ phone
 
 #### Defined in
 
-[v4-specification.ts:470](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L470)
+[v4-specification.ts:476](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L476)

--- a/packages/project/docs/interfaces/v4_specification.CoverCrop.md
+++ b/packages/project/docs/interfaces/v4_specification.CoverCrop.md
@@ -91,7 +91,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1546](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1546)
+[v4-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1552)
 
 ___
 
@@ -115,7 +115,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v4-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1759)
+[v4-specification.ts:1765](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1765)
 
 ___
 
@@ -163,7 +163,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1596](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1596)
+[v4-specification.ts:1602](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1602)
 
 ___
 
@@ -195,7 +195,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1294](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1294)
+[v4-specification.ts:1300](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1300)
 
 ___
 
@@ -237,7 +237,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1427](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1427)
+[v4-specification.ts:1433](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1433)
 
 ___
 
@@ -282,7 +282,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1521](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1521)
+[v4-specification.ts:1527](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1527)
 
 ___
 
@@ -323,7 +323,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1618](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1618)
+[v4-specification.ts:1624](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1624)
 
 ___
 
@@ -351,7 +351,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1310](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1310)
+[v4-specification.ts:1316](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1316)
 
 ___
 
@@ -391,7 +391,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1473](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1473)
+[v4-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1479)
 
 ___
 
@@ -436,7 +436,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1497)
+[v4-specification.ts:1503](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1503)
 
 ___
 
@@ -462,7 +462,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:1272](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1272)
+[v4-specification.ts:1278](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1278)
 
 ___
 
@@ -508,7 +508,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1452](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1452)
+[v4-specification.ts:1458](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1458)
 
 ___
 
@@ -558,7 +558,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1380](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1380)
+[v4-specification.ts:1386](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1386)
 
 ___
 
@@ -606,7 +606,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1571](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1571)
+[v4-specification.ts:1577](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1577)
 
 ___
 
@@ -648,7 +648,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1404](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1404)
+[v4-specification.ts:1410](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1410)
 
 ___
 
@@ -670,4 +670,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v4-specification.ts:1744](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1744)
+[v4-specification.ts:1750](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1750)

--- a/packages/project/docs/interfaces/v4_specification.Crop.md
+++ b/packages/project/docs/interfaces/v4_specification.Crop.md
@@ -95,7 +95,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1546](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1546)
+[v4-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1552)
 
 ___
 
@@ -143,7 +143,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1596](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1596)
+[v4-specification.ts:1602](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1602)
 
 ___
 
@@ -171,7 +171,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1294](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1294)
+[v4-specification.ts:1300](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1300)
 
 ___
 
@@ -213,7 +213,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1427](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1427)
+[v4-specification.ts:1433](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1433)
 
 ___
 
@@ -258,7 +258,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1521](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1521)
+[v4-specification.ts:1527](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1527)
 
 ___
 
@@ -299,7 +299,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1618](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1618)
+[v4-specification.ts:1624](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1624)
 
 ___
 
@@ -323,7 +323,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1310](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1310)
+[v4-specification.ts:1316](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1316)
 
 ___
 
@@ -363,7 +363,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1473](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1473)
+[v4-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1479)
 
 ___
 
@@ -408,7 +408,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1497)
+[v4-specification.ts:1503](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1503)
 
 ___
 
@@ -430,7 +430,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:1272](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1272)
+[v4-specification.ts:1278](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1278)
 
 ___
 
@@ -476,7 +476,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1452](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1452)
+[v4-specification.ts:1458](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1458)
 
 ___
 
@@ -526,7 +526,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1380](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1380)
+[v4-specification.ts:1386](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1386)
 
 ___
 
@@ -574,7 +574,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1571](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1571)
+[v4-specification.ts:1577](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1577)
 
 ___
 
@@ -616,4 +616,4 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1404](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1404)
+[v4-specification.ts:1410](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1410)

--- a/packages/project/docs/interfaces/v4_specification.CropEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.CropEvent.md
@@ -81,7 +81,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -103,7 +103,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -127,7 +127,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -155,4 +155,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)

--- a/packages/project/docs/interfaces/v4_specification.CropEvents.md
+++ b/packages/project/docs/interfaces/v4_specification.CropEvents.md
@@ -109,7 +109,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1546](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1546)
+[v4-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1552)
 
 ___
 
@@ -153,7 +153,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1596](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1596)
+[v4-specification.ts:1602](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1602)
 
 ___
 
@@ -191,7 +191,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1427](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1427)
+[v4-specification.ts:1433](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1433)
 
 ___
 
@@ -232,7 +232,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1521](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1521)
+[v4-specification.ts:1527](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1527)
 
 ___
 
@@ -269,7 +269,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1618](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1618)
+[v4-specification.ts:1624](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1624)
 
 ___
 
@@ -305,7 +305,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1473](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1473)
+[v4-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1479)
 
 ___
 
@@ -346,7 +346,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1497)
+[v4-specification.ts:1503](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1503)
 
 ___
 
@@ -388,7 +388,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1452](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1452)
+[v4-specification.ts:1458](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1458)
 
 ___
 
@@ -434,7 +434,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1380](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1380)
+[v4-specification.ts:1386](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1386)
 
 ___
 
@@ -478,7 +478,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1571](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1571)
+[v4-specification.ts:1577](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1577)
 
 ___
 
@@ -516,4 +516,4 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1404](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1404)
+[v4-specification.ts:1410](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1410)

--- a/packages/project/docs/interfaces/v4_specification.CropYear.md
+++ b/packages/project/docs/interfaces/v4_specification.CropYear.md
@@ -71,7 +71,7 @@ Due to a limitation at COMET farm, the maximum number of crops per [plantingYear
 
 #### Defined in
 
-[v4-specification.ts:1228](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1228)
+[v4-specification.ts:1234](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1234)
 
 ___
 
@@ -96,7 +96,7 @@ Nullable for backwards compatibility
 
 #### Defined in
 
-[v4-specification.ts:1242](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1242)
+[v4-specification.ts:1248](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1248)
 
 ___
 
@@ -124,4 +124,4 @@ The planting year that the herein defined [crops](#crops) property is associated
 
 #### Defined in
 
-[v4-specification.ts:1197](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1197)
+[v4-specification.ts:1203](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1203)

--- a/packages/project/docs/interfaces/v4_specification.FertilizerEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.FertilizerEvent.md
@@ -69,7 +69,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -95,7 +95,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -123,7 +123,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -147,7 +147,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v4-specification.ts:2163](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2163)
+[v4-specification.ts:2169](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2169)
 
 ___
 
@@ -171,7 +171,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:2134](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2134)
+[v4-specification.ts:2140](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2140)
 
 ___
 
@@ -203,7 +203,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)
 
 ___
 
@@ -230,4 +230,4 @@ As such, we default the type to "mixed blends" when this property is excluded/nu
 
 #### Defined in
 
-[v4-specification.ts:2150](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2150)
+[v4-specification.ts:2156](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2156)

--- a/packages/project/docs/interfaces/v4_specification.Field.md
+++ b/packages/project/docs/interfaces/v4_specification.Field.md
@@ -90,7 +90,7 @@ i.e. Is the field leased land?
 
 #### Defined in
 
-[v4-specification.ts:1053](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1053)
+[v4-specification.ts:1059](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1059)
 
 ___
 
@@ -117,7 +117,7 @@ A list of crop management details grouped by the crop planting year.
 
 #### Defined in
 
-[v4-specification.ts:1122](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1122)
+[v4-specification.ts:1128](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1128)
 
 ___
 
@@ -138,7 +138,7 @@ Earliest evidence is the first year a field has any digital or hard copy records
 
 #### Defined in
 
-[v4-specification.ts:955](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L955)
+[v4-specification.ts:961](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L961)
 
 ___
 
@@ -160,7 +160,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1138](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1138)
+[v4-specification.ts:1144](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1144)
 
 ___
 
@@ -176,7 +176,7 @@ if ownwer is operator or if this information will be communicated directly to th
 
 #### Defined in
 
-[v4-specification.ts:1067](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1067)
+[v4-specification.ts:1073](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1073)
 
 ___
 
@@ -198,7 +198,7 @@ The name of the field.
 
 #### Defined in
 
-[v4-specification.ts:1029](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1029)
+[v4-specification.ts:1035](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1035)
 
 ___
 
@@ -224,7 +224,7 @@ For additional guidance and limitation of boundary files, [refer to the FAQ here
 
 #### Defined in
 
-[v4-specification.ts:1104](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1104)
+[v4-specification.ts:1110](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1110)
 
 ___
 
@@ -271,7 +271,7 @@ during import (note: when historicLandManagement is defined as null in an import
 
 #### Defined in
 
-[v4-specification.ts:1010](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1010)
+[v4-specification.ts:1016](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1016)
 
 ___
 
@@ -295,7 +295,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1153](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1153)
+[v4-specification.ts:1159](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1159)
 
 ___
 
@@ -311,7 +311,7 @@ If this information will be communicated directly to the verifier.
 
 #### Defined in
 
-[v4-specification.ts:1060](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1060)
+[v4-specification.ts:1066](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1066)
 
 ___
 
@@ -329,7 +329,7 @@ legalAcres Number of acres in this parcel per your insurance policy.
 
 #### Defined in
 
-[v4-specification.ts:1035](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1035)
+[v4-specification.ts:1041](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1041)
 
 ___
 
@@ -349,7 +349,7 @@ legalPropertyDescription
 
 #### Defined in
 
-[v4-specification.ts:1087](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1087)
+[v4-specification.ts:1093](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1093)
 
 ___
 
@@ -365,7 +365,7 @@ If this information will be communicated directly to the verifier.
 
 #### Defined in
 
-[v4-specification.ts:1073](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1073)
+[v4-specification.ts:1079](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1079)
 
 ___
 
@@ -379,7 +379,7 @@ parcelNumber
 
 #### Defined in
 
-[v4-specification.ts:1079](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1079)
+[v4-specification.ts:1085](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1085)
 
 ___
 
@@ -398,7 +398,7 @@ Used to indicate that the available physical evidence does not corroborate the p
 
 #### Defined in
 
-[v4-specification.ts:964](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L964)
+[v4-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L970)
 
 ___
 
@@ -416,7 +416,7 @@ Details of new practice changes.
 
 #### Defined in
 
-[v4-specification.ts:976](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L976)
+[v4-specification.ts:982](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L982)
 
 ___
 
@@ -442,4 +442,4 @@ For more information on how to select a start year see [here](https://go.nori.co
 
 #### Defined in
 
-[v4-specification.ts:943](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L943)
+[v4-specification.ts:949](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L949)

--- a/packages/project/docs/interfaces/v4_specification.GrazingEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.GrazingEvent.md
@@ -67,7 +67,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -95,7 +95,7 @@ Number of days actively grazed from `CropEvent.date`
 
 #### Defined in
 
-[v4-specification.ts:2438](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2438)
+[v4-specification.ts:2444](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2444)
 
 ___
 
@@ -121,7 +121,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -149,7 +149,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -177,7 +177,7 @@ Percent of residue removed if known.
 
 #### Defined in
 
-[v4-specification.ts:2452](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2452)
+[v4-specification.ts:2458](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2458)
 
 ___
 
@@ -209,4 +209,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)

--- a/packages/project/docs/interfaces/v4_specification.HarvestEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.HarvestEvent.md
@@ -73,7 +73,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -99,7 +99,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -135,7 +135,7 @@ no
 
 #### Defined in
 
-[v4-specification.ts:1981](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1981)
+[v4-specification.ts:1987](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1987)
 
 ___
 
@@ -163,7 +163,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -211,7 +211,7 @@ Crop residue removed.
 
 #### Defined in
 
-[v4-specification.ts:2009](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2009)
+[v4-specification.ts:2015](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2015)
 
 ___
 
@@ -243,7 +243,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)
 
 ___
 
@@ -269,7 +269,7 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v4-specification.ts:1945](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1945)
+[v4-specification.ts:1951](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1951)
 
 ___
 
@@ -295,4 +295,4 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v4-specification.ts:1960](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1960)
+[v4-specification.ts:1966](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1966)

--- a/packages/project/docs/interfaces/v4_specification.HistoricCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v4_specification.HistoricCRPLandManagement.md
@@ -68,7 +68,7 @@ true
 
 #### Defined in
 
-[v4-specification.ts:715](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L715)
+[v4-specification.ts:721](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L721)
 
 ___
 
@@ -96,7 +96,7 @@ The CRP end year
 
 #### Defined in
 
-[v4-specification.ts:760](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L760)
+[v4-specification.ts:766](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L766)
 
 ___
 
@@ -124,7 +124,7 @@ The CRP start year
 
 #### Defined in
 
-[v4-specification.ts:746](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L746)
+[v4-specification.ts:752](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L752)
 
 ___
 
@@ -152,7 +152,7 @@ The type of CRP the field participated in. Only applicable if [crp](#crp) is set
 
 #### Defined in
 
-[v4-specification.ts:732](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L732)
+[v4-specification.ts:738](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L738)
 
 ___
 
@@ -172,7 +172,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v4-specification.ts:806](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L806)
+[v4-specification.ts:812](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L812)
 
 ___
 
@@ -190,7 +190,7 @@ How was the field managed after tillage
 
 #### Defined in
 
-[v4-specification.ts:826](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L826)
+[v4-specification.ts:832](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L832)
 
 ___
 
@@ -210,7 +210,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v4-specification.ts:773](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L773)
+[v4-specification.ts:779](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L779)
 
 ___
 
@@ -228,7 +228,7 @@ How was the field tilled before the field entered into CRP
 
 #### Defined in
 
-[v4-specification.ts:793](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L793)
+[v4-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L799)
 
 ___
 
@@ -276,4 +276,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v4-specification.ts:593](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L593)
+[v4-specification.ts:599](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L599)

--- a/packages/project/docs/interfaces/v4_specification.HistoricLandManagement.md
+++ b/packages/project/docs/interfaces/v4_specification.HistoricLandManagement.md
@@ -68,4 +68,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v4-specification.ts:593](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L593)
+[v4-specification.ts:599](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L599)

--- a/packages/project/docs/interfaces/v4_specification.HistoricNonCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v4_specification.HistoricNonCRPLandManagement.md
@@ -54,7 +54,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:628](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L628)
+[v4-specification.ts:634](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L634)
 
 ___
 
@@ -102,7 +102,7 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v4-specification.ts:593](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L593)
+[v4-specification.ts:599](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L599)
 
 ___
 
@@ -138,7 +138,7 @@ The type of soil or crop disturbance events used on the field between 1980 and 2
 
 #### Defined in
 
-[v4-specification.ts:651](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L651)
+[v4-specification.ts:657](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L657)
 
 ___
 
@@ -156,4 +156,4 @@ A description of how the land was managed between 1980 and 2000.
 
 #### Defined in
 
-[v4-specification.ts:665](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L665)
+[v4-specification.ts:671](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L671)

--- a/packages/project/docs/interfaces/v4_specification.IrrigationEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.IrrigationEvent.md
@@ -65,7 +65,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -91,7 +91,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -119,7 +119,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -151,7 +151,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)
 
 ___
 
@@ -175,4 +175,4 @@ The irrigation volume in inches. If volume is 0, simply do not define an irrigat
 
 #### Defined in
 
-[v4-specification.ts:2362](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2362)
+[v4-specification.ts:2368](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2368)

--- a/packages/project/docs/interfaces/v4_specification.LimingEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.LimingEvent.md
@@ -70,7 +70,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -96,7 +96,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -124,7 +124,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -156,7 +156,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)
 
 ___
 
@@ -180,7 +180,7 @@ The liming amount (in tons per acre).
 
 #### Defined in
 
-[v4-specification.ts:2407](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2407)
+[v4-specification.ts:2413](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2413)
 
 ___
 
@@ -200,4 +200,4 @@ The liming type.
 
 #### Defined in
 
-[v4-specification.ts:2394](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2394)
+[v4-specification.ts:2400](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2400)

--- a/packages/project/docs/interfaces/v4_specification.OrchardOrVineyardCrop.md
+++ b/packages/project/docs/interfaces/v4_specification.OrchardOrVineyardCrop.md
@@ -91,7 +91,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1546](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1546)
+[v4-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1552)
 
 ___
 
@@ -123,7 +123,7 @@ Note: if a crop ever changes classifications during the lifetime of the field (i
 
 #### Defined in
 
-[v4-specification.ts:1669](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1669)
+[v4-specification.ts:1675](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1675)
 
 ___
 
@@ -171,7 +171,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1596](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1596)
+[v4-specification.ts:1602](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1602)
 
 ___
 
@@ -203,7 +203,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1294](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1294)
+[v4-specification.ts:1300](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1300)
 
 ___
 
@@ -245,7 +245,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1427](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1427)
+[v4-specification.ts:1433](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1433)
 
 ___
 
@@ -290,7 +290,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1521](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1521)
+[v4-specification.ts:1527](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1527)
 
 ___
 
@@ -331,7 +331,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1618](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1618)
+[v4-specification.ts:1624](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1624)
 
 ___
 
@@ -359,7 +359,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1310](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1310)
+[v4-specification.ts:1316](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1316)
 
 ___
 
@@ -399,7 +399,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1473](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1473)
+[v4-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1479)
 
 ___
 
@@ -444,7 +444,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1497)
+[v4-specification.ts:1503](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1503)
 
 ___
 
@@ -470,7 +470,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:1272](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1272)
+[v4-specification.ts:1278](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1278)
 
 ___
 
@@ -516,7 +516,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1452](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1452)
+[v4-specification.ts:1458](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1458)
 
 ___
 
@@ -566,7 +566,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1380](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1380)
+[v4-specification.ts:1386](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1386)
 
 ___
 
@@ -614,7 +614,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1571](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1571)
+[v4-specification.ts:1577](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1577)
 
 ___
 
@@ -656,7 +656,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1404](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1404)
+[v4-specification.ts:1410](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1410)
 
 ___
 
@@ -678,4 +678,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v4-specification.ts:1648](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1648)
+[v4-specification.ts:1654](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1654)

--- a/packages/project/docs/interfaces/v4_specification.OrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.OrganicMatterEvent.md
@@ -67,7 +67,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2317](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2317)
+[v4-specification.ts:2323](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2323)
 
 ___
 
@@ -103,7 +103,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -129,7 +129,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -157,7 +157,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -181,7 +181,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:2286](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2286)
+[v4-specification.ts:2292](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2292)
 
 ___
 
@@ -213,7 +213,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2333](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2333)
+[v4-specification.ts:2339](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2339)
 
 ___
 
@@ -245,7 +245,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2302](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2302)
+[v4-specification.ts:2308](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2308)
 
 ___
 
@@ -277,4 +277,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)

--- a/packages/project/docs/interfaces/v4_specification.PerennialCrop.md
+++ b/packages/project/docs/interfaces/v4_specification.PerennialCrop.md
@@ -91,7 +91,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1546](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1546)
+[v4-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1552)
 
 ___
 
@@ -115,7 +115,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v4-specification.ts:1714](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1714)
+[v4-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1720)
 
 ___
 
@@ -163,7 +163,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1596](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1596)
+[v4-specification.ts:1602](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1602)
 
 ___
 
@@ -195,7 +195,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1294](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1294)
+[v4-specification.ts:1300](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1300)
 
 ___
 
@@ -237,7 +237,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1427](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1427)
+[v4-specification.ts:1433](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1433)
 
 ___
 
@@ -282,7 +282,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1521](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1521)
+[v4-specification.ts:1527](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1527)
 
 ___
 
@@ -323,7 +323,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1618](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1618)
+[v4-specification.ts:1624](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1624)
 
 ___
 
@@ -351,7 +351,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1310](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1310)
+[v4-specification.ts:1316](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1316)
 
 ___
 
@@ -391,7 +391,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1473](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1473)
+[v4-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1479)
 
 ___
 
@@ -436,7 +436,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1497)
+[v4-specification.ts:1503](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1503)
 
 ___
 
@@ -462,7 +462,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:1272](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1272)
+[v4-specification.ts:1278](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1278)
 
 ___
 
@@ -508,7 +508,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1452](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1452)
+[v4-specification.ts:1458](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1458)
 
 ___
 
@@ -558,7 +558,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1380](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1380)
+[v4-specification.ts:1386](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1386)
 
 ___
 
@@ -606,7 +606,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1571](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1571)
+[v4-specification.ts:1577](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1577)
 
 ___
 
@@ -648,7 +648,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1404](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1404)
+[v4-specification.ts:1410](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1410)
 
 ___
 
@@ -670,4 +670,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v4-specification.ts:1699](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1699)
+[v4-specification.ts:1705](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1705)

--- a/packages/project/docs/interfaces/v4_specification.PlantingEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.PlantingEvent.md
@@ -65,7 +65,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -91,7 +91,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -119,7 +119,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -151,4 +151,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)

--- a/packages/project/docs/interfaces/v4_specification.PracticeChangesAdopted.md
+++ b/packages/project/docs/interfaces/v4_specification.PracticeChangesAdopted.md
@@ -40,7 +40,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:869](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L869)
+[v4-specification.ts:875](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L875)
 
 ___
 
@@ -56,7 +56,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:845](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L845)
+[v4-specification.ts:851](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L851)
 
 ___
 
@@ -72,7 +72,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:881](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L881)
+[v4-specification.ts:887](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L887)
 
 ___
 
@@ -88,7 +88,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:851](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L851)
+[v4-specification.ts:857](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L857)
 
 ___
 
@@ -104,7 +104,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:875](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L875)
+[v4-specification.ts:881](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L881)
 
 ___
 
@@ -120,7 +120,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:863](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L863)
+[v4-specification.ts:869](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L869)
 
 ___
 
@@ -136,4 +136,4 @@ false
 
 #### Defined in
 
-[v4-specification.ts:857](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L857)
+[v4-specification.ts:863](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L863)

--- a/packages/project/docs/interfaces/v4_specification.Project.md
+++ b/packages/project/docs/interfaces/v4_specification.Project.md
@@ -9,15 +9,15 @@ A project encapsulates a set of fields. This is the top-level interface of Nori'
 A project may represent either a complete farming operation for a single operator or a batch
 of fields from a data aggregator.
 
-@$id https://schema.nori.com/soil/4-0-6
+@$id https://schema.nori.com/soil/4-0-7
 
 **`Example`**
 
-<caption>A project that uses specification v4.0.6 and contains a list of fields:</caption>
+<caption>A project that uses specification v4.0.7 and contains a list of fields:</caption>
 
 ```js
 {
- "version": "4.0.6",
+ "version": "4.0.7",
  "fields": [
    ...fields
  ]
@@ -35,6 +35,7 @@ of fields from a data aggregator.
 - [fields](v4_specification.Project.md#fields)
 - [id](v4_specification.Project.md#id)
 - [primaryContact](v4_specification.Project.md#primarycontact)
+- [projectName](v4_specification.Project.md#projectname)
 - [supplierId](v4_specification.Project.md#supplierid)
 - [totalCroppedAcres](v4_specification.Project.md#totalcroppedacres)
 - [totalFarmAcres](v4_specification.Project.md#totalfarmacres)
@@ -60,7 +61,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:389](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L389)
+[v4-specification.ts:389](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L389)
 
 ___
 
@@ -76,7 +77,7 @@ if import file represents a batch rather than an entire project for a single far
 
 #### Defined in
 
-[v4-specification.ts:351](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L351)
+[v4-specification.ts:351](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L351)
 
 ___
 
@@ -106,7 +107,7 @@ An array of fields defining annual crop management practices.
 
 #### Defined in
 
-[v4-specification.ts:443](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L443)
+[v4-specification.ts:449](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L449)
 
 ___
 
@@ -130,7 +131,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:404](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L404)
+[v4-specification.ts:404](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L404)
 
 ___
 
@@ -144,7 +145,23 @@ This will be the primary point of contract for verifiers.
 
 #### Defined in
 
-[v4-specification.ts:345](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L345)
+[v4-specification.ts:345](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L345)
+
+___
+
+### projectName
+
+• `Optional` **projectName**: `string`
+
+The name for the project to be created.
+
+**`Nullable`**
+
+External systems leave this null.
+
+#### Defined in
+
+[v4-specification.ts:425](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L425)
 
 ___
 
@@ -168,7 +185,7 @@ External systems leave this null.
 
 #### Defined in
 
-[v4-specification.ts:419](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L419)
+[v4-specification.ts:419](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L419)
 
 ___
 
@@ -190,7 +207,7 @@ if import file represents a batch rather than an entire project for a single far
 
 #### Defined in
 
-[v4-specification.ts:375](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L375)
+[v4-specification.ts:375](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L375)
 
 ___
 
@@ -212,7 +229,7 @@ if import file represents a batch rather than an entire project for a single far
 
 #### Defined in
 
-[v4-specification.ts:363](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L363)
+[v4-specification.ts:363](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L363)
 
 ___
 
@@ -227,9 +244,9 @@ The specification version. This information is used to determine the logic Nori 
 **`Example`**
 
 ```js
-"version": "4.0.6"
+"version": "4.0.7"
 ```
 
 #### Defined in
 
-[v4-specification.ts:338](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L338)
+[v4-specification.ts:338](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L338)

--- a/packages/project/docs/interfaces/v4_specification.PruningEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.PruningEvent.md
@@ -63,7 +63,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -89,7 +89,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -117,7 +117,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -149,4 +149,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)

--- a/packages/project/docs/interfaces/v4_specification.SlurryOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.SlurryOrganicMatterEvent.md
@@ -70,7 +70,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2317](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2317)
+[v4-specification.ts:2323](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2323)
 
 ___
 
@@ -106,7 +106,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -132,7 +132,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -160,7 +160,7 @@ Amount of organic matter applied per acre (gallons per acre).
 
 #### Defined in
 
-[v4-specification.ts:2253](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2253)
+[v4-specification.ts:2259](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2259)
 
 ___
 
@@ -188,7 +188,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -216,7 +216,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:2286](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2286)
+[v4-specification.ts:2292](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2292)
 
 ___
 
@@ -252,7 +252,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2333](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2333)
+[v4-specification.ts:2339](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2339)
 
 ___
 
@@ -288,7 +288,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2302](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2302)
+[v4-specification.ts:2308](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2308)
 
 ___
 
@@ -320,7 +320,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)
 
 ___
 
@@ -340,4 +340,4 @@ The organic matter or manure classification type.
 
 #### Defined in
 
-[v4-specification.ts:2239](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2239)
+[v4-specification.ts:2245](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2245)

--- a/packages/project/docs/interfaces/v4_specification.SoilOrCropDisturbanceEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.SoilOrCropDisturbanceEvent.md
@@ -66,7 +66,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -92,7 +92,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -120,7 +120,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -140,7 +140,7 @@ The name/alias that the soil or crop disturbance events practice is known by. Th
 
 #### Defined in
 
-[v4-specification.ts:2036](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2036)
+[v4-specification.ts:2042](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2042)
 
 ___
 
@@ -172,7 +172,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)
 
 ___
 
@@ -266,4 +266,4 @@ You can find a list of common equivalents [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v4-specification.ts:2103](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2103)
+[v4-specification.ts:2109](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2109)

--- a/packages/project/docs/interfaces/v4_specification.SolidOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.SolidOrganicMatterEvent.md
@@ -70,7 +70,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2317](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2317)
+[v4-specification.ts:2323](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2323)
 
 ___
 
@@ -106,7 +106,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1844)
+[v4-specification.ts:1850](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1850)
 
 ___
 
@@ -132,7 +132,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1859](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1859)
+[v4-specification.ts:1865](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1865)
 
 ___
 
@@ -160,7 +160,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1874](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1874)
+[v4-specification.ts:1880](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1880)
 
 ___
 
@@ -188,7 +188,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:2286](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2286)
+[v4-specification.ts:2292](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2292)
 
 ___
 
@@ -224,7 +224,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2333](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2333)
+[v4-specification.ts:2339](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2339)
 
 ___
 
@@ -260,7 +260,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2302](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2302)
+[v4-specification.ts:2308](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2308)
 
 ___
 
@@ -292,7 +292,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1895](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L1895)
+[v4-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L1901)
 
 ___
 
@@ -320,7 +320,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v4-specification.ts:2208](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2208)
+[v4-specification.ts:2214](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2214)
 
 ___
 
@@ -340,4 +340,4 @@ The solid/dry organic matter or manure classification type.
 
 #### Defined in
 
-[v4-specification.ts:2194](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L2194)
+[v4-specification.ts:2200](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L2200)

--- a/packages/project/docs/modules/utils_convertfromv2tov1.md
+++ b/packages/project/docs/modules/utils_convertfromv2tov1.md
@@ -27,4 +27,4 @@
 
 #### Defined in
 
-[utils/convertFromV2ToV1.ts:14](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/utils/convertFromV2ToV1.ts#L14)
+[utils/convertFromV2ToV1.ts:14](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/utils/convertFromV2ToV1.ts#L14)

--- a/packages/project/docs/modules/v3_specification.md
+++ b/packages/project/docs/modules/v3_specification.md
@@ -82,7 +82,7 @@ Throughout this documentation you will come across some vocab that indicate to w
 
 #### Defined in
 
-[v3-specification.ts:36](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L36)
+[v3-specification.ts:36](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L36)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:72](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L72)
+[v3-specification.ts:72](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L72)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:142](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L142)
+[v3-specification.ts:142](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L142)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:180](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L180)
+[v3-specification.ts:180](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L180)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:113](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L113)
+[v3-specification.ts:113](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L113)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:133](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L133)
+[v3-specification.ts:133](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L133)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:84](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L84)
+[v3-specification.ts:84](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L84)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:166](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L166)
+[v3-specification.ts:166](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L166)
 
 ___
 
@@ -162,4 +162,4 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:92](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v3-specification.ts#L92)
+[v3-specification.ts:92](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v3-specification.ts#L92)

--- a/packages/project/docs/modules/v4_specification.md
+++ b/packages/project/docs/modules/v4_specification.md
@@ -6,7 +6,7 @@
 
 Nori croplands project import file format.
 
-Version: 4.0.6
+Version: 4.0.7
 
 Provides the definitions for Nori croplands project data import using typescript interfaces.
 
@@ -82,7 +82,7 @@ You can find definitions for all of the interfaces in Nori croplands project fro
 
 #### Defined in
 
-[v4-specification.ts:33](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L33)
+[v4-specification.ts:33](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L33)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:123](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L123)
+[v4-specification.ts:123](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L123)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:226](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L226)
+[v4-specification.ts:226](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L226)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:289](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L289)
+[v4-specification.ts:289](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L289)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:168](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L168)
+[v4-specification.ts:168](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L168)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:206](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L206)
+[v4-specification.ts:206](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L206)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:139](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L139)
+[v4-specification.ts:139](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L139)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:252](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L252)
+[v4-specification.ts:252](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L252)
 
 ___
 
@@ -162,4 +162,4 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:147](https://github.com/nori-dot-eco/nori-dot-com/blob/ba4a1c9/packages/project/src/v4-specification.ts#L147)
+[v4-specification.ts:147](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/v4-specification.ts#L147)

--- a/packages/project/docs/modules/validation.md
+++ b/packages/project/docs/modules/validation.md
@@ -21,7 +21,7 @@ Takes input data and checks whether its contents are valid or not. When the data
 <caption>Validating project data using data that has an invalid number of fields defined:</caption>
 
 ```js
-validateProjectData({version:'4.0.6', data}); // returns {valid:false, ...errors}
+validateProjectData(data); // returns {valid:false, ...errors}
 ```
 
 #### Parameters

--- a/packages/project/docs/modules/validation.md
+++ b/packages/project/docs/modules/validation.md
@@ -43,4 +43,4 @@ validateProjectData(data); // returns {valid:false, ...errors}
 
 #### Defined in
 
-[validation.ts:81](https://github.com/nori-dot-eco/nori-dot-com/blob/01ec85d/packages/project/src/validation.ts#L81)
+[validation.ts:81](https://github.com/nori-dot-eco/nori-dot-com/blob/cc4e2a7/packages/project/src/validation.ts#L81)

--- a/packages/project/src/__tests__/validation.test.ts
+++ b/packages/project/src/__tests__/validation.test.ts
@@ -12,7 +12,7 @@ import type {
 type ProjectOrAny<T> = T extends Project ? Project : any;
 
 const BASIC_UNFORMATTED_VALID_PROJECT: Project = {
-  version: '4.0.6',
+  version: '4.0.7',
   primaryContact: {},
   fields: [
     {
@@ -95,7 +95,7 @@ const BASIC_UNFORMATTED_VALID_PROJECT: Project = {
 };
 
 const BASIC_UNFORMATTED_INVALID_PROJECT: Project = {
-  version: '4.0.6',
+  version: '4.0.7',
   primaryContact: {},
   fields: [
     {
@@ -463,7 +463,7 @@ describe('validation', () => {
           describe('when the type is excluded or null', () => {
             it('should return true for validation', () => {
               const data: Project = {
-                version: '4.0.6',
+                version: '4.0.7',
                 primaryContact: {},
                 fields: [
                   {

--- a/packages/project/src/json/v4-specification.json
+++ b/packages/project/src/json/v4-specification.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.nori.com/soil/4-0-6",
+    "$id": "https://schema.nori.com/soil/4-0-7",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
@@ -3536,6 +3536,14 @@
             "$ref": "#/definitions/ContactInfo",
             "description": "primaryContact Contact info for the operator or data aggregator preparing this file.\n\nThis will be the primary point of contract for verifiers.",
             "title": "primaryContact"
+        },
+        "projectName": {
+            "description": "The name for the project to be created.",
+            "title": "projectName",
+            "type": [
+                "string",
+                "null"
+            ]
         },
         "supplierId": {
             "description": "Nori's internal supplier identifier.\n\nUsed to correlate projects / batches to a supplier.",

--- a/packages/project/src/v4-specification.ts
+++ b/packages/project/src/v4-specification.ts
@@ -3,7 +3,7 @@
  *
  * Nori croplands project import file format.
  *
- * Version: 4.0.6
+ * Version: 4.0.7
  *
  * Provides the definitions for Nori croplands project data import using typescript interfaces.
  *
@@ -299,13 +299,13 @@ export const limingTypes = [
  * A project may represent either a complete farming operation for a single operator or a batch
  * of fields from a data aggregator.
  *
- * @$id https://schema.nori.com/soil/4-0-6
+ * @$id https://schema.nori.com/soil/4-0-7
  *
- * @example <caption>A project that uses specification v4.0.6 and contains a list of fields:</caption>
+ * @example <caption>A project that uses specification v4.0.7 and contains a list of fields:</caption>
  *
  * ```js
  * {
- *  "version": "4.0.6",
+ *  "version": "4.0.7",
  *  "fields": [
  *    ...fields
  *  ]
@@ -331,7 +331,7 @@ export interface Project {
    * @example
    *
    * ```js
-   * "version": "4.0.6"
+   * "version": "4.0.7"
    * ```
    *
    */
@@ -417,6 +417,12 @@ export interface Project {
    *
    */
   supplierId?: string;
+  /**
+   * The name for the project to be created.
+   * 
+   * @nullable External systems leave this null.
+   */
+  projectName?: string;
   /**
    * An array of fields defining annual crop management practices.
    *

--- a/packages/project/src/validation.ts
+++ b/packages/project/src/validation.ts
@@ -74,7 +74,7 @@ const validationRules = {
  * @example <caption>Validating project data using data that has an invalid number of fields defined:</caption>
  *
  * ```js
- * validateProjectData({version:'4.0.6', data}); // returns {valid:false, ...errors}
+ * validateProjectData(data); // returns {valid:false, ...errors}
  * ```
  *
  */


### PR DESCRIPTION
For the croplands import work, we want to be able to specify a project name in the input file, similar to how we do with the supplier ID. I added a field called `projectName` to the spec, and bumped the version. You can view the actual changes [here](https://github.com/nori-dot-eco/nori-dot-com/pull/214/commits/9a2e7d241b242d9801013a9192ddfd16355b865e), the second commit is just spam from make docs updating the links in every file