### PR TITLE
Hotfix release - NO-2318 - smart default failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   environment:
     NODE_ENV: test
   docker:
-    - image: cimg/node:16.18.0
+    - image: circleci/node:14.18.1
 
 jobs:
   setup-tests:


### PR DESCRIPTION
This PR is for a hotfix to production. This rolls back our node16 upgrade due to issues affecting streaming file uploads to graphql

This hotfix approach follows the gitflow hotfix process outlined here:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/7808563/199628707-044591c6-2f76-4b87-873b-f79b1f6d6216.png">
