### PR TITLE
NO-2318 - smart default failures

### DIFF
--- a/packages/project/docs/interfaces/v4_specification.Field.md
+++ b/packages/project/docs/interfaces/v4_specification.Field.md
@@ -85,7 +85,7 @@ i.e. Is the field leased land?
 <caption>When the operator is the land owner:</caption>
 
 ```js
-"assignmentOfAuthority": true
+"assignmentOfAuthority": false
 ```
 
 #### Defined in

--- a/packages/project/src/v4-specification.ts
+++ b/packages/project/src/v4-specification.ts
@@ -419,7 +419,7 @@ export interface Project {
   supplierId?: string;
   /**
    * The name for the project to be created.
-   * 
+   *
    * @nullable External systems leave this null.
    */
   projectName?: string;
@@ -906,7 +906,7 @@ export interface PracticeChangesAdopted {
  *  "parcelNumber": "",
  *  "legalPropertyDescription": "15 83 40 N 17.70 A OF W 33.67 A SW SE",
  *  "geojson": {
- *    // exmaple GeoJSON:
+ *    // example GeoJSON:
  *    "type": "Polygon",
  *     "coordinates": [
  *         [[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]
@@ -1052,7 +1052,7 @@ export interface Field {
    * @example <caption>When the operator is the land owner:</caption>
    *
    * ```js
-   * "assignmentOfAuthority": true
+   * "assignmentOfAuthority": false
    * ```
    *
    */


### PR DESCRIPTION
This PR (draft) is for reverts the node16 upgrade to unblock smart default functionality in the supplier portal. Since the node16 updates affect the entire monorepo, including our CI pipelines, the revert is being applied in each submodule as well

Changes in this PR include:
* Revert of node16 commit 
* Revert of node16 CI image update