### PR TITLE
v4.2.0 Schema updates

### DIFF
--- a/packages/project/CHANGELOG.md
+++ b/packages/project/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.2.0 (November 28, 2022)
+* Added `historical extrapolation` as an option to `CropYear.dataSourceType`.
+* Removed nullable annotation from `FertilizerEvent.lbsOfNPerAcre` and applied a schema-level default of 0 to that field.
+
 # v4.1.0 (November 17, 2022)
 * Simplified schema to reduce complexity.
     * Removed `AnnualCrop`, `CoverCrop`, `OrchardOrVineyardCrop` and `PerennialCrop`.

--- a/packages/project/docs/interfaces/v3_specification.AnnualCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.AnnualCrop.md
@@ -85,7 +85,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -109,7 +109,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v3-specification.ts:1253](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1253)
+[v3-specification.ts:1253](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1253)
 
 ___
 
@@ -141,7 +141,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -177,7 +177,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -208,7 +208,7 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L837)
 
 ___
 
@@ -238,7 +238,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -273,7 +273,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -299,7 +299,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -337,7 +337,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -367,7 +367,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -399,7 +399,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -425,4 +425,4 @@ must specify one of the allowed crop types if you are specifying an annual crop
 
 #### Defined in
 
-[v3-specification.ts:1238](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1238)
+[v3-specification.ts:1238](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1238)

--- a/packages/project/docs/interfaces/v3_specification.AnnualCropHarvestEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.AnnualCropHarvestEvent.md
@@ -79,7 +79,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -115,7 +115,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1369)
+[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1369)
 
 ___
 
@@ -167,7 +167,7 @@ Crop residue removed.
 
 #### Defined in
 
-[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1397)
+[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1397)
 
 ___
 
@@ -193,7 +193,7 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v3-specification.ts:1431](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1431)
+[v3-specification.ts:1431](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1431)
 
 ___
 
@@ -219,4 +219,4 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v3-specification.ts:1446](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1446)
+[v3-specification.ts:1446](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1446)

--- a/packages/project/docs/interfaces/v3_specification.BurningEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.BurningEvent.md
@@ -46,4 +46,4 @@ The type of burning, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:1947](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1947)
+[v3-specification.ts:1947](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1947)

--- a/packages/project/docs/interfaces/v3_specification.CoverCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.CoverCrop.md
@@ -81,7 +81,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -105,7 +105,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v3-specification.ts:1201](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1201)
+[v3-specification.ts:1201](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1201)
 
 ___
 
@@ -137,7 +137,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -173,7 +173,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -203,7 +203,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -238,7 +238,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -264,7 +264,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -302,7 +302,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -332,7 +332,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -364,7 +364,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -386,4 +386,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1186](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1186)
+[v3-specification.ts:1186](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1186)

--- a/packages/project/docs/interfaces/v3_specification.CropEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.CropEvent.md
@@ -73,4 +73,4 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)

--- a/packages/project/docs/interfaces/v3_specification.CropEventRange.md
+++ b/packages/project/docs/interfaces/v3_specification.CropEventRange.md
@@ -50,7 +50,7 @@ The last date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 a
 
 #### Defined in
 
-[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1333)
+[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1333)
 
 ___
 
@@ -74,4 +74,4 @@ The first date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 
 
 #### Defined in
 
-[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1320)
+[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1320)

--- a/packages/project/docs/interfaces/v3_specification.CropEvents.md
+++ b/packages/project/docs/interfaces/v3_specification.CropEvents.md
@@ -94,7 +94,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -122,7 +122,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -154,7 +154,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -180,7 +180,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -211,7 +211,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -245,7 +245,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -273,4 +273,4 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L891)

--- a/packages/project/docs/interfaces/v3_specification.CropManagementEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.CropManagementEvent.md
@@ -75,7 +75,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -107,7 +107,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1369)
+[v3-specification.ts:1369](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1369)
 
 ___
 
@@ -155,4 +155,4 @@ Crop residue removed.
 
 #### Defined in
 
-[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1397)
+[v3-specification.ts:1397](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1397)

--- a/packages/project/docs/interfaces/v3_specification.CropYear.md
+++ b/packages/project/docs/interfaces/v3_specification.CropYear.md
@@ -70,7 +70,7 @@ Due to a limitation at COMET farm, the maximum number of crops per [plantingYear
 
 #### Defined in
 
-[v3-specification.ts:752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L752)
+[v3-specification.ts:752](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L752)
 
 ___
 
@@ -98,4 +98,4 @@ The planting year that the herein defined [crops](#crops) property is associated
 
 #### Defined in
 
-[v3-specification.ts:717](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L717)
+[v3-specification.ts:717](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L717)

--- a/packages/project/docs/interfaces/v3_specification.FertilizerEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.FertilizerEvent.md
@@ -75,7 +75,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -99,7 +99,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v3-specification.ts:1611](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1611)
+[v3-specification.ts:1611](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1611)
 
 ___
 
@@ -123,7 +123,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1583](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1583)
+[v3-specification.ts:1583](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1583)
 
 ___
 
@@ -149,4 +149,4 @@ Note that the fertilizer type does not currently impact quantification as it onl
 
 #### Defined in
 
-[v3-specification.ts:1598](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1598)
+[v3-specification.ts:1598](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1598)

--- a/packages/project/docs/interfaces/v3_specification.Field.md
+++ b/packages/project/docs/interfaces/v3_specification.Field.md
@@ -72,7 +72,7 @@ during import (note: when acres is defined as null in an import file it will ins
 
 #### Defined in
 
-[v3-specification.ts:651](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L651)
+[v3-specification.ts:651](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L651)
 
 ___
 
@@ -99,7 +99,7 @@ A list of crop management details grouped by the crop planting year.
 
 #### Defined in
 
-[v3-specification.ts:686](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L686)
+[v3-specification.ts:686](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L686)
 
 ___
 
@@ -128,7 +128,7 @@ The name of the field.
 
 #### Defined in
 
-[v3-specification.ts:638](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L638)
+[v3-specification.ts:638](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L638)
 
 ___
 
@@ -154,7 +154,7 @@ For additional guidance and limitation of boundary files, [refer to the FAQ here
 
 #### Defined in
 
-[v3-specification.ts:668](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L668)
+[v3-specification.ts:668](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L668)
 
 ___
 
@@ -201,7 +201,7 @@ during import (note: when historicLandManagement is defined as null in an import
 
 #### Defined in
 
-[v3-specification.ts:617](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L617)
+[v3-specification.ts:617](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L617)
 
 ___
 
@@ -227,4 +227,4 @@ For more information on how to select a start year see [here](https://go.nori.co
 
 #### Defined in
 
-[v3-specification.ts:583](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L583)
+[v3-specification.ts:583](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L583)

--- a/packages/project/docs/interfaces/v3_specification.GrazingEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.GrazingEvent.md
@@ -58,7 +58,7 @@ The last date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 a
 
 #### Defined in
 
-[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1333)
+[v3-specification.ts:1333](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1333)
 
 ___
 
@@ -96,7 +96,7 @@ Zero and one are equivalent and indicate continuous grazing.
 
 #### Defined in
 
-[v3-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1901)
+[v3-specification.ts:1901](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1901)
 
 ___
 
@@ -124,7 +124,7 @@ The first date that the event occurred (formatted as MM/DD/YYYY and YYYY > 2000 
 
 #### Defined in
 
-[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1320)
+[v3-specification.ts:1320](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1320)
 
 ___
 
@@ -152,4 +152,4 @@ The percentage of forage consumed by the animals per rest period days.
 
 #### Defined in
 
-[v3-specification.ts:1915](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1915)
+[v3-specification.ts:1915](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1915)

--- a/packages/project/docs/interfaces/v3_specification.HarvestableCropEvents.md
+++ b/packages/project/docs/interfaces/v3_specification.HarvestableCropEvents.md
@@ -62,4 +62,4 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L837)

--- a/packages/project/docs/interfaces/v3_specification.HistoricCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v3_specification.HistoricCRPLandManagement.md
@@ -68,7 +68,7 @@ Whether the field participated in CRP or not.
 
 #### Defined in
 
-[v3-specification.ts:418](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L418)
+[v3-specification.ts:418](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L418)
 
 ___
 
@@ -96,7 +96,7 @@ The CRP end year
 
 #### Defined in
 
-[v3-specification.ts:463](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L463)
+[v3-specification.ts:463](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L463)
 
 ___
 
@@ -124,7 +124,7 @@ The CRP start year
 
 #### Defined in
 
-[v3-specification.ts:449](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L449)
+[v3-specification.ts:449](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L449)
 
 ___
 
@@ -152,7 +152,7 @@ The type of CRP the field participated in. Only applicable if [crp](#crp) is set
 
 #### Defined in
 
-[v3-specification.ts:435](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L435)
+[v3-specification.ts:435](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L435)
 
 ___
 
@@ -172,7 +172,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v3-specification.ts:509](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L509)
+[v3-specification.ts:509](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L509)
 
 ___
 
@@ -190,7 +190,7 @@ How was the field managed after tillage
 
 #### Defined in
 
-[v3-specification.ts:529](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L529)
+[v3-specification.ts:529](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L529)
 
 ___
 
@@ -210,7 +210,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v3-specification.ts:476](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L476)
+[v3-specification.ts:476](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L476)
 
 ___
 
@@ -228,7 +228,7 @@ How was the field tilled before the field entered into CRP
 
 #### Defined in
 
-[v3-specification.ts:496](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L496)
+[v3-specification.ts:496](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L496)
 
 ___
 
@@ -276,4 +276,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L296)
+[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L296)

--- a/packages/project/docs/interfaces/v3_specification.HistoricLandManagement.md
+++ b/packages/project/docs/interfaces/v3_specification.HistoricLandManagement.md
@@ -68,4 +68,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L296)
+[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L296)

--- a/packages/project/docs/interfaces/v3_specification.HistoricNonCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v3_specification.HistoricNonCRPLandManagement.md
@@ -54,7 +54,7 @@ Whether the field participated in CRP or not.
 
 #### Defined in
 
-[v3-specification.ts:331](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L331)
+[v3-specification.ts:331](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L331)
 
 ___
 
@@ -102,7 +102,7 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L296)
+[v3-specification.ts:296](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L296)
 
 ___
 
@@ -138,7 +138,7 @@ The type of soil or crop disturbance events used on the field between 1980 and 2
 
 #### Defined in
 
-[v3-specification.ts:354](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L354)
+[v3-specification.ts:354](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L354)
 
 ___
 
@@ -156,4 +156,4 @@ A description of how the land was managed between 1980 and 2000.
 
 #### Defined in
 
-[v3-specification.ts:368](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L368)
+[v3-specification.ts:368](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L368)

--- a/packages/project/docs/interfaces/v3_specification.IrrigationEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.IrrigationEvent.md
@@ -71,7 +71,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -95,4 +95,4 @@ The irrigation volume in inches. If volume is 0, simply do not define an irrigat
 
 #### Defined in
 
-[v3-specification.ts:1806](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1806)
+[v3-specification.ts:1806](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1806)

--- a/packages/project/docs/interfaces/v3_specification.LimingEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.LimingEvent.md
@@ -46,7 +46,7 @@ The date that the liming occurred. Currently, liming dates do not impact quantif
 
 #### Defined in
 
-[v3-specification.ts:1861](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1861)
+[v3-specification.ts:1861](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1861)
 
 ___
 
@@ -70,7 +70,7 @@ The liming amount (in tons per acre).
 
 #### Defined in
 
-[v3-specification.ts:1848](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1848)
+[v3-specification.ts:1848](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1848)
 
 ___
 
@@ -90,4 +90,4 @@ The liming type.
 
 #### Defined in
 
-[v3-specification.ts:1835](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1835)
+[v3-specification.ts:1835](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1835)

--- a/packages/project/docs/interfaces/v3_specification.OrchardOrVineyardCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.OrchardOrVineyardCrop.md
@@ -88,7 +88,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -120,7 +120,7 @@ Note: if a crop ever changes classifications during the lifetime of the field (i
 
 #### Defined in
 
-[v3-specification.ts:1071](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1071)
+[v3-specification.ts:1071](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1071)
 
 ___
 
@@ -152,7 +152,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -188,7 +188,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -219,7 +219,7 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L837)
 
 ___
 
@@ -249,7 +249,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -284,7 +284,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -310,7 +310,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -348,7 +348,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -378,7 +378,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -406,7 +406,7 @@ Indicates if the crop was pruned.
 
 #### Defined in
 
-[v3-specification.ts:1089](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1089)
+[v3-specification.ts:1089](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1089)
 
 ___
 
@@ -434,7 +434,7 @@ Indicates if the crop was renewed or cleared.
 
 #### Defined in
 
-[v3-specification.ts:1106](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1106)
+[v3-specification.ts:1106](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1106)
 
 ___
 
@@ -466,7 +466,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -488,4 +488,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1050](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1050)
+[v3-specification.ts:1050](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1050)

--- a/packages/project/docs/interfaces/v3_specification.OrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.OrganicMatterEvent.md
@@ -65,7 +65,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1720)
+[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1720)
 
 ___
 
@@ -99,7 +99,7 @@ during import
 
 #### Defined in
 
-[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1759)
+[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1759)
 
 ___
 
@@ -144,7 +144,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -168,7 +168,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1706)
+[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1706)
 
 ___
 
@@ -204,7 +204,7 @@ during import (explicitly specify null if you are unsure what the value is)
 
 #### Defined in
 
-[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1777)
+[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1777)
 
 ___
 
@@ -242,4 +242,4 @@ during import (when defined as undefined, a default value will be assigned)
 
 #### Defined in
 
-[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1740)
+[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1740)

--- a/packages/project/docs/interfaces/v3_specification.PerennialCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.PerennialCrop.md
@@ -84,7 +84,7 @@ if no burning ever occurred, explicitly specify `burningEvent` as `null`
 
 #### Defined in
 
-[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1014)
+[v3-specification.ts:1014](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1014)
 
 ___
 
@@ -108,7 +108,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v3-specification.ts:1155](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1155)
+[v3-specification.ts:1155](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1155)
 
 ___
 
@@ -140,7 +140,7 @@ A list of fertilizer events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L910)
+[v3-specification.ts:910](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L910)
 
 ___
 
@@ -176,7 +176,7 @@ during import (explicitly specify null if grazing did not occur, otherwise exclu
 
 #### Defined in
 
-[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L991)
+[v3-specification.ts:991](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L991)
 
 ___
 
@@ -207,7 +207,7 @@ that was removed on the grain harvest, regardless of removal date.
 
 #### Defined in
 
-[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L837)
+[v3-specification.ts:837](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L837)
 
 ___
 
@@ -237,7 +237,7 @@ A list of irrigation events, if applicable.
 
 #### Defined in
 
-[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L950)
+[v3-specification.ts:950](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L950)
 
 ___
 
@@ -272,7 +272,7 @@ during import (explicitly specify null if no liming events occurred, otherwise e
 
 #### Defined in
 
-[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L970)
+[v3-specification.ts:970](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L970)
 
 ___
 
@@ -298,7 +298,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -336,7 +336,7 @@ during import (explicitly specify null if no organic matter events occurred, oth
 
 #### Defined in
 
-[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L933)
+[v3-specification.ts:933](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L933)
 
 ___
 
@@ -366,7 +366,7 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L799)
 
 ___
 
@@ -398,7 +398,7 @@ All crops will need to define a soil or crop disturbance event <= the associated
 
 #### Defined in
 
-[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L891)
+[v3-specification.ts:891](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L891)
 
 ___
 
@@ -420,4 +420,4 @@ You can find a list of accepted crops [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1140](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1140)
+[v3-specification.ts:1140](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1140)

--- a/packages/project/docs/interfaces/v3_specification.PlantedCrop.md
+++ b/packages/project/docs/interfaces/v3_specification.PlantedCrop.md
@@ -53,7 +53,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L784)
+[v3-specification.ts:784](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L784)
 
 ___
 
@@ -79,4 +79,4 @@ If a crop is ever replanted, define the crop again and add it to a new `CropYear
 
 #### Defined in
 
-[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L799)
+[v3-specification.ts:799](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L799)

--- a/packages/project/docs/interfaces/v3_specification.Project.md
+++ b/packages/project/docs/interfaces/v3_specification.Project.md
@@ -70,7 +70,7 @@ An array of fields defining annual crop management practices.
 
 #### Defined in
 
-[v3-specification.ts:254](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L254)
+[v3-specification.ts:254](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L254)
 
 ___
 
@@ -97,4 +97,4 @@ The specification version. This information is used to determine the logic Nori 
 
 #### Defined in
 
-[v3-specification.ts:228](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L228)
+[v3-specification.ts:228](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L228)

--- a/packages/project/docs/interfaces/v3_specification.SlurryOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.SlurryOrganicMatterEvent.md
@@ -67,7 +67,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1720)
+[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1720)
 
 ___
 
@@ -105,7 +105,7 @@ during import
 
 #### Defined in
 
-[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1759)
+[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1759)
 
 ___
 
@@ -150,7 +150,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -178,7 +178,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1706)
+[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1706)
 
 ___
 
@@ -218,7 +218,7 @@ during import (explicitly specify null if you are unsure what the value is)
 
 #### Defined in
 
-[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1777)
+[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1777)
 
 ___
 
@@ -260,7 +260,7 @@ during import (when defined as undefined, a default value will be assigned)
 
 #### Defined in
 
-[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1740)
+[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1740)
 
 ___
 
@@ -280,4 +280,4 @@ The organic matter or manure classification type.
 
 #### Defined in
 
-[v3-specification.ts:1673](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1673)
+[v3-specification.ts:1673](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1673)

--- a/packages/project/docs/interfaces/v3_specification.SoilOrCropDisturbanceEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.SoilOrCropDisturbanceEvent.md
@@ -72,7 +72,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -102,7 +102,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1479)
+[v3-specification.ts:1479](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1479)
 
 ___
 
@@ -204,4 +204,4 @@ You can find a list of common equivalents [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v3-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1552)
+[v3-specification.ts:1552](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1552)

--- a/packages/project/docs/interfaces/v3_specification.SolidOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v3_specification.SolidOrganicMatterEvent.md
@@ -67,7 +67,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1720)
+[v3-specification.ts:1720](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1720)
 
 ___
 
@@ -105,7 +105,7 @@ during import
 
 #### Defined in
 
-[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1759)
+[v3-specification.ts:1759](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1759)
 
 ___
 
@@ -150,7 +150,7 @@ during import (note: when dates are defined as null in an import file, the data 
 
 #### Defined in
 
-[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1291)
+[v3-specification.ts:1291](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1291)
 
 ___
 
@@ -178,7 +178,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1706)
+[v3-specification.ts:1706](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1706)
 
 ___
 
@@ -218,7 +218,7 @@ during import (explicitly specify null if you are unsure what the value is)
 
 #### Defined in
 
-[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1777)
+[v3-specification.ts:1777](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1777)
 
 ___
 
@@ -260,7 +260,7 @@ during import (when defined as undefined, a default value will be assigned)
 
 #### Defined in
 
-[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1740)
+[v3-specification.ts:1740](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1740)
 
 ___
 
@@ -280,4 +280,4 @@ The solid/dry organic matter or manure classification type.
 
 #### Defined in
 
-[v3-specification.ts:1642](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L1642)
+[v3-specification.ts:1642](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L1642)

--- a/packages/project/docs/interfaces/v4_specification.Address.md
+++ b/packages/project/docs/interfaces/v4_specification.Address.md
@@ -47,7 +47,7 @@ US-ND
 
 #### Defined in
 
-[v4-specification.ts:545](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L545)
+[v4-specification.ts:545](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L545)
 
 ___
 
@@ -69,7 +69,7 @@ In the US use FIPS code: https://www.nrcs.usda.gov/wps/portal/nrcs/detail/nation
 
 #### Defined in
 
-[v4-specification.ts:555](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L555)
+[v4-specification.ts:555](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L555)
 
 ___
 
@@ -89,7 +89,7 @@ Fargo
 
 #### Defined in
 
-[v4-specification.ts:535](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L535)
+[v4-specification.ts:535](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L535)
 
 ___
 
@@ -111,7 +111,7 @@ US
 
 #### Defined in
 
-[v4-specification.ts:565](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L565)
+[v4-specification.ts:565](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L565)
 
 ___
 
@@ -137,7 +137,7 @@ PO Box 56789
 
 #### Defined in
 
-[v4-specification.ts:517](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L517)
+[v4-specification.ts:517](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L517)
 
 ___
 
@@ -163,4 +163,4 @@ Station 99
 
 #### Defined in
 
-[v4-specification.ts:527](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L527)
+[v4-specification.ts:527](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L527)

--- a/packages/project/docs/interfaces/v4_specification.BurningEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.BurningEvent.md
@@ -63,7 +63,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -89,7 +89,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -117,7 +117,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -149,4 +149,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)

--- a/packages/project/docs/interfaces/v4_specification.ClearingAndRenewalEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.ClearingAndRenewalEvent.md
@@ -65,7 +65,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -91,7 +91,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -119,7 +119,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -147,7 +147,7 @@ Percentage or orchard or vinyard that was cleared and renewed.
 
 #### Defined in
 
-[v4-specification.ts:2353](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2353)
+[v4-specification.ts:2359](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2359)
 
 ___
 
@@ -179,4 +179,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)

--- a/packages/project/docs/interfaces/v4_specification.ContactInfo.md
+++ b/packages/project/docs/interfaces/v4_specification.ContactInfo.md
@@ -34,7 +34,7 @@ email
 
 #### Defined in
 
-[v4-specification.ts:490](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L490)
+[v4-specification.ts:490](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L490)
 
 ___
 
@@ -48,7 +48,7 @@ The project's primary contract person.  Provided to the verified.
 
 #### Defined in
 
-[v4-specification.ts:478](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L478)
+[v4-specification.ts:478](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L478)
 
 ___
 
@@ -62,4 +62,4 @@ phone
 
 #### Defined in
 
-[v4-specification.ts:484](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L484)
+[v4-specification.ts:484](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L484)

--- a/packages/project/docs/interfaces/v4_specification.Crop.md
+++ b/packages/project/docs/interfaces/v4_specification.Crop.md
@@ -91,7 +91,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1581](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1581)
+[v4-specification.ts:1587](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1587)
 
 ___
 
@@ -115,7 +115,7 @@ You can find a list of acceptable crop classifications per crop `name` [here](ht
 
 #### Defined in
 
-[v4-specification.ts:1344](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1344)
+[v4-specification.ts:1350](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1350)
 
 ___
 
@@ -161,7 +161,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1627](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1627)
+[v4-specification.ts:1633](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1633)
 
 ___
 
@@ -189,7 +189,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1293](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1293)
+[v4-specification.ts:1299](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1299)
 
 ___
 
@@ -233,7 +233,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1466](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1466)
+[v4-specification.ts:1472](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1472)
 
 ___
 
@@ -276,7 +276,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1556](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1556)
+[v4-specification.ts:1562](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1562)
 
 ___
 
@@ -319,7 +319,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1649](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1649)
+[v4-specification.ts:1655](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1655)
 
 ___
 
@@ -344,7 +344,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1310](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1310)
+[v4-specification.ts:1316](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1316)
 
 ___
 
@@ -386,7 +386,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1512](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1512)
+[v4-specification.ts:1518](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1518)
 
 ___
 
@@ -429,7 +429,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1534](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1534)
+[v4-specification.ts:1540](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1540)
 
 ___
 
@@ -451,7 +451,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:1271](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1271)
+[v4-specification.ts:1277](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1277)
 
 ___
 
@@ -497,7 +497,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1491](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1491)
+[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1497)
 
 ___
 
@@ -549,7 +549,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1419](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1419)
+[v4-specification.ts:1425](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1425)
 
 ___
 
@@ -595,7 +595,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1604](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1604)
+[v4-specification.ts:1610](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1610)
 
 ___
 
@@ -639,7 +639,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1443](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1443)
+[v4-specification.ts:1449](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1449)
 
 ___
 
@@ -665,4 +665,4 @@ must specify one of the allowed crop types=
 
 #### Defined in
 
-[v4-specification.ts:1326](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1326)
+[v4-specification.ts:1332](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1332)

--- a/packages/project/docs/interfaces/v4_specification.CropEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.CropEvent.md
@@ -81,7 +81,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -103,7 +103,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -127,7 +127,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -155,4 +155,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)

--- a/packages/project/docs/interfaces/v4_specification.CropEvents.md
+++ b/packages/project/docs/interfaces/v4_specification.CropEvents.md
@@ -111,7 +111,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1581](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1581)
+[v4-specification.ts:1587](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1587)
 
 ___
 
@@ -153,7 +153,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1627](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1627)
+[v4-specification.ts:1633](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1633)
 
 ___
 
@@ -193,7 +193,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1466](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1466)
+[v4-specification.ts:1472](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1472)
 
 ___
 
@@ -232,7 +232,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1556](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1556)
+[v4-specification.ts:1562](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1562)
 
 ___
 
@@ -271,7 +271,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1649](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1649)
+[v4-specification.ts:1655](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1655)
 
 ___
 
@@ -309,7 +309,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1512](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1512)
+[v4-specification.ts:1518](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1518)
 
 ___
 
@@ -348,7 +348,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1534](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1534)
+[v4-specification.ts:1540](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1540)
 
 ___
 
@@ -390,7 +390,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1491](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1491)
+[v4-specification.ts:1497](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1497)
 
 ___
 
@@ -438,7 +438,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1419](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1419)
+[v4-specification.ts:1425](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1425)
 
 ___
 
@@ -480,7 +480,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1604](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1604)
+[v4-specification.ts:1610](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1610)
 
 ___
 
@@ -520,4 +520,4 @@ false
 
 #### Defined in
 
-[v4-specification.ts:1443](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1443)
+[v4-specification.ts:1449](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1449)

--- a/packages/project/docs/interfaces/v4_specification.CropYear.md
+++ b/packages/project/docs/interfaces/v4_specification.CropYear.md
@@ -16,7 +16,7 @@ Crop management details grouped by a planting year.
  "crops": [
    // ... crops that were planted in year 2000
  ],
- "dataSourceType": "GROWER_REPORTED",
+ "dataSourceType": "grower reported",
 }
 ```
 
@@ -69,13 +69,13 @@ A list of crops for a given planting year.
 
 #### Defined in
 
-[v4-specification.ts:1227](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1227)
+[v4-specification.ts:1227](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1227)
 
 ___
 
 ### dataSourceType
 
-• `Optional` **dataSourceType**: ``"grower reported"`` \| ``"projected"``
+• `Optional` **dataSourceType**: ``"grower reported"`` \| ``"projected"`` \| ``"historical extrapolation"``
 
 Flag indicating whether data is historical data reported by the grower,
 or a projection of future data.
@@ -86,15 +86,23 @@ grower reported
 
 **`Example`**
 
-<caption>When data is from a projection of future data:</caption>
+<caption>When data is from a projection of anticipated future practice:</caption>
 
 ```js
 "dataSourceType": "projected"
 ```
 
+**`Example`**
+
+<caption>When historical data is extrapolated back based on more recent practice data:</caption>
+
+```js
+"dataSourceType": "historical extrapolation"
+```
+
 #### Defined in
 
-[v4-specification.ts:1241](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1241)
+[v4-specification.ts:1247](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1247)
 
 ___
 
@@ -122,4 +130,4 @@ The planting year that the herein defined [crops](#crops) property is associated
 
 #### Defined in
 
-[v4-specification.ts:1198](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1198)
+[v4-specification.ts:1198](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1198)

--- a/packages/project/docs/interfaces/v4_specification.FertilizerEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.FertilizerEvent.md
@@ -69,7 +69,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -95,7 +95,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -123,7 +123,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -133,9 +133,9 @@ ___
 
 Amount of nitrogen applied in lbs/ac.
 
-**`Nullable`**
+**`Default`**
 
-during import (specify null if you are unsure)
+0
 
 **`Example`**
 
@@ -147,7 +147,7 @@ during import (specify null if you are unsure)
 
 #### Defined in
 
-[v4-specification.ts:2020](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2020)
+[v4-specification.ts:2026](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2026)
 
 ___
 
@@ -171,7 +171,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:1991](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1991)
+[v4-specification.ts:1997](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1997)
 
 ___
 
@@ -203,7 +203,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)
 
 ___
 
@@ -230,4 +230,4 @@ As such, we default the type to "mixed blends" when this property is excluded/nu
 
 #### Defined in
 
-[v4-specification.ts:2007](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2007)
+[v4-specification.ts:2013](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2013)

--- a/packages/project/docs/interfaces/v4_specification.Field.md
+++ b/packages/project/docs/interfaces/v4_specification.Field.md
@@ -90,7 +90,7 @@ i.e. Is the field leased land?
 
 #### Defined in
 
-[v4-specification.ts:1067](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1067)
+[v4-specification.ts:1067](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1067)
 
 ___
 
@@ -115,7 +115,7 @@ A list of crop management details grouped by the crop planting year.
 
 #### Defined in
 
-[v4-specification.ts:1134](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1134)
+[v4-specification.ts:1134](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1134)
 
 ___
 
@@ -136,7 +136,7 @@ Earliest evidence is the first year a field has any digital or hard copy records
 
 #### Defined in
 
-[v4-specification.ts:969](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L969)
+[v4-specification.ts:969](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L969)
 
 ___
 
@@ -158,7 +158,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1150](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1150)
+[v4-specification.ts:1150](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1150)
 
 ___
 
@@ -174,7 +174,7 @@ if ownwer is operator or if this information will be communicated directly to th
 
 #### Defined in
 
-[v4-specification.ts:1081](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1081)
+[v4-specification.ts:1081](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1081)
 
 ___
 
@@ -196,7 +196,7 @@ The name of the field.
 
 #### Defined in
 
-[v4-specification.ts:1043](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1043)
+[v4-specification.ts:1043](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1043)
 
 ___
 
@@ -222,7 +222,7 @@ For additional guidance and limitation of boundary files, [refer to the FAQ here
 
 #### Defined in
 
-[v4-specification.ts:1118](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1118)
+[v4-specification.ts:1118](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1118)
 
 ___
 
@@ -269,7 +269,7 @@ during import (note: when historicLandManagement is defined as null in an import
 
 #### Defined in
 
-[v4-specification.ts:1024](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1024)
+[v4-specification.ts:1024](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1024)
 
 ___
 
@@ -293,7 +293,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1165](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1165)
+[v4-specification.ts:1165](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1165)
 
 ___
 
@@ -309,7 +309,7 @@ If this information will be communicated directly to the verifier.
 
 #### Defined in
 
-[v4-specification.ts:1074](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1074)
+[v4-specification.ts:1074](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1074)
 
 ___
 
@@ -327,7 +327,7 @@ legalAcres Number of acres in this parcel per your insurance policy.
 
 #### Defined in
 
-[v4-specification.ts:1049](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1049)
+[v4-specification.ts:1049](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1049)
 
 ___
 
@@ -347,7 +347,7 @@ legalPropertyDescription
 
 #### Defined in
 
-[v4-specification.ts:1101](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1101)
+[v4-specification.ts:1101](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1101)
 
 ___
 
@@ -363,7 +363,7 @@ If this information will be communicated directly to the verifier.
 
 #### Defined in
 
-[v4-specification.ts:1087](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1087)
+[v4-specification.ts:1087](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1087)
 
 ___
 
@@ -377,7 +377,7 @@ parcelNumber
 
 #### Defined in
 
-[v4-specification.ts:1093](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1093)
+[v4-specification.ts:1093](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1093)
 
 ___
 
@@ -396,7 +396,7 @@ Used to indicate that the available physical evidence does not corroborate the p
 
 #### Defined in
 
-[v4-specification.ts:978](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L978)
+[v4-specification.ts:978](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L978)
 
 ___
 
@@ -414,7 +414,7 @@ Details of new practice changes.
 
 #### Defined in
 
-[v4-specification.ts:990](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L990)
+[v4-specification.ts:990](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L990)
 
 ___
 
@@ -440,4 +440,4 @@ For more information on how to select a start year see [here](https://go.nori.co
 
 #### Defined in
 
-[v4-specification.ts:957](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L957)
+[v4-specification.ts:957](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L957)

--- a/packages/project/docs/interfaces/v4_specification.GrazingEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.GrazingEvent.md
@@ -67,7 +67,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -95,7 +95,7 @@ Number of days actively grazed from `CropEvent.date`
 
 #### Defined in
 
-[v4-specification.ts:2295](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2295)
+[v4-specification.ts:2301](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2301)
 
 ___
 
@@ -121,7 +121,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -149,7 +149,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -177,7 +177,7 @@ Percent of residue removed if known.
 
 #### Defined in
 
-[v4-specification.ts:2309](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2309)
+[v4-specification.ts:2315](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2315)
 
 ___
 
@@ -209,4 +209,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)

--- a/packages/project/docs/interfaces/v4_specification.HarvestEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.HarvestEvent.md
@@ -73,7 +73,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -99,7 +99,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -135,7 +135,7 @@ no
 
 #### Defined in
 
-[v4-specification.ts:1838](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1838)
+[v4-specification.ts:1844](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1844)
 
 ___
 
@@ -163,7 +163,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -211,7 +211,7 @@ Crop residue removed.
 
 #### Defined in
 
-[v4-specification.ts:1866](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1866)
+[v4-specification.ts:1872](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1872)
 
 ___
 
@@ -243,7 +243,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)
 
 ___
 
@@ -269,7 +269,7 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v4-specification.ts:1802](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1802)
+[v4-specification.ts:1808](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1808)
 
 ___
 
@@ -295,4 +295,4 @@ The current version of quantification does not consider yield when producing est
 
 #### Defined in
 
-[v4-specification.ts:1817](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1817)
+[v4-specification.ts:1823](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1823)

--- a/packages/project/docs/interfaces/v4_specification.HistoricCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v4_specification.HistoricCRPLandManagement.md
@@ -68,7 +68,7 @@ true
 
 #### Defined in
 
-[v4-specification.ts:729](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L729)
+[v4-specification.ts:729](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L729)
 
 ___
 
@@ -96,7 +96,7 @@ The CRP end year
 
 #### Defined in
 
-[v4-specification.ts:774](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L774)
+[v4-specification.ts:774](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L774)
 
 ___
 
@@ -124,7 +124,7 @@ The CRP start year
 
 #### Defined in
 
-[v4-specification.ts:760](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L760)
+[v4-specification.ts:760](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L760)
 
 ___
 
@@ -152,7 +152,7 @@ The type of CRP the field participated in. Only applicable if [crp](#crp) is set
 
 #### Defined in
 
-[v4-specification.ts:746](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L746)
+[v4-specification.ts:746](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L746)
 
 ___
 
@@ -172,7 +172,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v4-specification.ts:820](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L820)
+[v4-specification.ts:820](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L820)
 
 ___
 
@@ -190,7 +190,7 @@ How was the field managed after tillage
 
 #### Defined in
 
-[v4-specification.ts:840](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L840)
+[v4-specification.ts:840](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L840)
 
 ___
 
@@ -210,7 +210,7 @@ To find applicable values per field location, see [here](https://docs.google.com
 
 #### Defined in
 
-[v4-specification.ts:787](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L787)
+[v4-specification.ts:787](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L787)
 
 ___
 
@@ -228,7 +228,7 @@ How was the field tilled before the field entered into CRP
 
 #### Defined in
 
-[v4-specification.ts:807](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L807)
+[v4-specification.ts:807](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L807)
 
 ___
 
@@ -276,4 +276,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v4-specification.ts:607](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L607)
+[v4-specification.ts:607](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L607)

--- a/packages/project/docs/interfaces/v4_specification.HistoricLandManagement.md
+++ b/packages/project/docs/interfaces/v4_specification.HistoricLandManagement.md
@@ -68,4 +68,4 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v4-specification.ts:607](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L607)
+[v4-specification.ts:607](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L607)

--- a/packages/project/docs/interfaces/v4_specification.HistoricNonCRPLandManagement.md
+++ b/packages/project/docs/interfaces/v4_specification.HistoricNonCRPLandManagement.md
@@ -54,7 +54,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:642](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L642)
+[v4-specification.ts:642](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L642)
 
 ___
 
@@ -102,7 +102,7 @@ A description of how the land was managed before 1980.
 
 #### Defined in
 
-[v4-specification.ts:607](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L607)
+[v4-specification.ts:607](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L607)
 
 ___
 
@@ -138,7 +138,7 @@ The type of soil or crop disturbance events used on the field between 1980 and 2
 
 #### Defined in
 
-[v4-specification.ts:665](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L665)
+[v4-specification.ts:665](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L665)
 
 ___
 
@@ -156,4 +156,4 @@ A description of how the land was managed between 1980 and 2000.
 
 #### Defined in
 
-[v4-specification.ts:679](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L679)
+[v4-specification.ts:679](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L679)

--- a/packages/project/docs/interfaces/v4_specification.IrrigationEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.IrrigationEvent.md
@@ -65,7 +65,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -91,7 +91,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -119,7 +119,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -151,7 +151,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)
 
 ___
 
@@ -175,4 +175,4 @@ The irrigation volume in inches. If volume is 0, simply do not define an irrigat
 
 #### Defined in
 
-[v4-specification.ts:2219](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2219)
+[v4-specification.ts:2225](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2225)

--- a/packages/project/docs/interfaces/v4_specification.LimingEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.LimingEvent.md
@@ -70,7 +70,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -96,7 +96,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -124,7 +124,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -156,7 +156,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)
 
 ___
 
@@ -180,7 +180,7 @@ The liming amount (in tons per acre).
 
 #### Defined in
 
-[v4-specification.ts:2264](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2264)
+[v4-specification.ts:2270](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2270)
 
 ___
 
@@ -200,4 +200,4 @@ The liming type.
 
 #### Defined in
 
-[v4-specification.ts:2251](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2251)
+[v4-specification.ts:2257](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2257)

--- a/packages/project/docs/interfaces/v4_specification.OrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.OrganicMatterEvent.md
@@ -67,7 +67,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2174](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2174)
+[v4-specification.ts:2180](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2180)
 
 ___
 
@@ -103,7 +103,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -129,7 +129,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -157,7 +157,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -181,7 +181,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:2143](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2143)
+[v4-specification.ts:2149](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2149)
 
 ___
 
@@ -213,7 +213,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2190](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2190)
+[v4-specification.ts:2196](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2196)
 
 ___
 
@@ -245,7 +245,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2159](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2159)
+[v4-specification.ts:2165](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2165)
 
 ___
 
@@ -277,4 +277,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)

--- a/packages/project/docs/interfaces/v4_specification.PlantingEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.PlantingEvent.md
@@ -65,7 +65,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -91,7 +91,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -119,7 +119,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -151,4 +151,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)

--- a/packages/project/docs/interfaces/v4_specification.PracticeChangesAdopted.md
+++ b/packages/project/docs/interfaces/v4_specification.PracticeChangesAdopted.md
@@ -40,7 +40,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:883](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L883)
+[v4-specification.ts:883](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L883)
 
 ___
 
@@ -56,7 +56,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:859](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L859)
+[v4-specification.ts:859](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L859)
 
 ___
 
@@ -72,7 +72,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:895](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L895)
+[v4-specification.ts:895](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L895)
 
 ___
 
@@ -88,7 +88,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:865](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L865)
+[v4-specification.ts:865](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L865)
 
 ___
 
@@ -104,7 +104,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:889](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L889)
+[v4-specification.ts:889](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L889)
 
 ___
 
@@ -120,7 +120,7 @@ false
 
 #### Defined in
 
-[v4-specification.ts:877](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L877)
+[v4-specification.ts:877](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L877)
 
 ___
 
@@ -136,4 +136,4 @@ false
 
 #### Defined in
 
-[v4-specification.ts:871](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L871)
+[v4-specification.ts:871](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L871)

--- a/packages/project/docs/interfaces/v4_specification.Project.md
+++ b/packages/project/docs/interfaces/v4_specification.Project.md
@@ -9,15 +9,15 @@ A project encapsulates a set of fields. This is the top-level interface of Nori'
 A project may represent either a complete farming operation for a single operator or a batch
 of fields from a data aggregator.
 
-@$id https://schema.nori.com/soil/4-0-7
+@$id https://schema.nori.com/soil/4-2-0
 
 **`Example`**
 
-<caption>A project that uses specification v4.1.0 and contains a list of fields:</caption>
+<caption>A project that uses specification v4.2.0 and contains a list of fields:</caption>
 
 ```js
 {
- "version": "4.1.0",
+ "version": "4.2.0",
  "fields": [
    ...fields
  ]
@@ -61,7 +61,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:397](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L397)
+[v4-specification.ts:397](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L397)
 
 ___
 
@@ -77,7 +77,7 @@ if import file represents a batch rather than an entire project for a single far
 
 #### Defined in
 
-[v4-specification.ts:359](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L359)
+[v4-specification.ts:359](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L359)
 
 ___
 
@@ -107,7 +107,7 @@ An array of fields defining annual crop management practices.
 
 #### Defined in
 
-[v4-specification.ts:457](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L457)
+[v4-specification.ts:457](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L457)
 
 ___
 
@@ -131,7 +131,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:412](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L412)
+[v4-specification.ts:412](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L412)
 
 ___
 
@@ -145,7 +145,7 @@ This will be the primary point of contract for verifiers.
 
 #### Defined in
 
-[v4-specification.ts:353](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L353)
+[v4-specification.ts:353](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L353)
 
 ___
 
@@ -161,7 +161,7 @@ External systems leave this null.
 
 #### Defined in
 
-[v4-specification.ts:433](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L433)
+[v4-specification.ts:433](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L433)
 
 ___
 
@@ -185,7 +185,7 @@ External systems leave this null.
 
 #### Defined in
 
-[v4-specification.ts:427](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L427)
+[v4-specification.ts:427](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L427)
 
 ___
 
@@ -207,7 +207,7 @@ if import file represents a batch rather than an entire project for a single far
 
 #### Defined in
 
-[v4-specification.ts:383](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L383)
+[v4-specification.ts:383](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L383)
 
 ___
 
@@ -229,7 +229,7 @@ if import file represents a batch rather than an entire project for a single far
 
 #### Defined in
 
-[v4-specification.ts:371](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L371)
+[v4-specification.ts:371](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L371)
 
 ___
 
@@ -244,9 +244,9 @@ The specification version. This information is used to determine the logic Nori 
 **`Example`**
 
 ```js
-"version": "4.1.0"
+"version": "4.2.0"
 ```
 
 #### Defined in
 
-[v4-specification.ts:346](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L346)
+[v4-specification.ts:346](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L346)

--- a/packages/project/docs/interfaces/v4_specification.PruningEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.PruningEvent.md
@@ -63,7 +63,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -89,7 +89,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -117,7 +117,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -149,4 +149,4 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)

--- a/packages/project/docs/interfaces/v4_specification.SlurryOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.SlurryOrganicMatterEvent.md
@@ -70,7 +70,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2174](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2174)
+[v4-specification.ts:2180](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2180)
 
 ___
 
@@ -106,7 +106,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -132,7 +132,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -160,7 +160,7 @@ Amount of organic matter applied per acre (gallons per acre).
 
 #### Defined in
 
-[v4-specification.ts:2110](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2110)
+[v4-specification.ts:2116](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2116)
 
 ___
 
@@ -188,7 +188,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -216,7 +216,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:2143](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2143)
+[v4-specification.ts:2149](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2149)
 
 ___
 
@@ -252,7 +252,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2190](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2190)
+[v4-specification.ts:2196](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2196)
 
 ___
 
@@ -288,7 +288,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2159](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2159)
+[v4-specification.ts:2165](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2165)
 
 ___
 
@@ -320,7 +320,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)
 
 ___
 
@@ -340,4 +340,4 @@ The organic matter or manure classification type.
 
 #### Defined in
 
-[v4-specification.ts:2096](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2096)
+[v4-specification.ts:2102](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2102)

--- a/packages/project/docs/interfaces/v4_specification.SoilOrCropDisturbanceEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.SoilOrCropDisturbanceEvent.md
@@ -66,7 +66,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -92,7 +92,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -120,7 +120,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -140,7 +140,7 @@ The name/alias that the soil or crop disturbance events practice is known by. Th
 
 #### Defined in
 
-[v4-specification.ts:1893](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1893)
+[v4-specification.ts:1899](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1899)
 
 ___
 
@@ -172,7 +172,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)
 
 ___
 
@@ -266,4 +266,4 @@ You can find a list of common equivalents [here](https://go.nori.com/inputs).
 
 #### Defined in
 
-[v4-specification.ts:1960](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1960)
+[v4-specification.ts:1966](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1966)

--- a/packages/project/docs/interfaces/v4_specification.SolidOrganicMatterEvent.md
+++ b/packages/project/docs/interfaces/v4_specification.SolidOrganicMatterEvent.md
@@ -70,7 +70,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2174](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2174)
+[v4-specification.ts:2180](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2180)
 
 ___
 
@@ -106,7 +106,7 @@ date
 
 #### Defined in
 
-[v4-specification.ts:1701](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1701)
+[v4-specification.ts:1707](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1707)
 
 ___
 
@@ -132,7 +132,7 @@ Used to correlate data back to the originating system and to synchronize repeate
 
 #### Defined in
 
-[v4-specification.ts:1716](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1716)
+[v4-specification.ts:1722](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1722)
 
 ___
 
@@ -160,7 +160,7 @@ External systems pass null or omit the property for new projects.
 
 #### Defined in
 
-[v4-specification.ts:1731](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1731)
+[v4-specification.ts:1737](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1737)
 
 ___
 
@@ -188,7 +188,7 @@ this property will be deprecated in the future
 
 #### Defined in
 
-[v4-specification.ts:2143](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2143)
+[v4-specification.ts:2149](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2149)
 
 ___
 
@@ -224,7 +224,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2190](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2190)
+[v4-specification.ts:2196](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2196)
 
 ___
 
@@ -260,7 +260,7 @@ A default based on the selected type will be used if not specified here.
 
 #### Defined in
 
-[v4-specification.ts:2159](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2159)
+[v4-specification.ts:2165](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2165)
 
 ___
 
@@ -292,7 +292,7 @@ Optional field to indicate what system this data point originated from.
 
 #### Defined in
 
-[v4-specification.ts:1752](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L1752)
+[v4-specification.ts:1758](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L1758)
 
 ___
 
@@ -320,7 +320,7 @@ Amount of organic matter or manure applied per acre (in tons per acre for solid/
 
 #### Defined in
 
-[v4-specification.ts:2065](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2065)
+[v4-specification.ts:2071](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2071)
 
 ___
 
@@ -340,4 +340,4 @@ The solid/dry organic matter or manure classification type.
 
 #### Defined in
 
-[v4-specification.ts:2051](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L2051)
+[v4-specification.ts:2057](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L2057)

--- a/packages/project/docs/modules/utils_convertfromv2tov1.md
+++ b/packages/project/docs/modules/utils_convertfromv2tov1.md
@@ -27,4 +27,4 @@
 
 #### Defined in
 
-[utils/convertFromV2ToV1.ts:14](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/utils/convertFromV2ToV1.ts#L14)
+[utils/convertFromV2ToV1.ts:14](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/utils/convertFromV2ToV1.ts#L14)

--- a/packages/project/docs/modules/v3_specification.md
+++ b/packages/project/docs/modules/v3_specification.md
@@ -82,7 +82,7 @@ Throughout this documentation you will come across some vocab that indicate to w
 
 #### Defined in
 
-[v3-specification.ts:36](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L36)
+[v3-specification.ts:36](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L36)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:72](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L72)
+[v3-specification.ts:72](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L72)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:142](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L142)
+[v3-specification.ts:142](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L142)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:180](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L180)
+[v3-specification.ts:180](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L180)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:113](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L113)
+[v3-specification.ts:113](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L113)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:133](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L133)
+[v3-specification.ts:133](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L133)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:84](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L84)
+[v3-specification.ts:84](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L84)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:166](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L166)
+[v3-specification.ts:166](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L166)
 
 ___
 
@@ -162,4 +162,4 @@ ___
 
 #### Defined in
 
-[v3-specification.ts:92](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v3-specification.ts#L92)
+[v3-specification.ts:92](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v3-specification.ts#L92)

--- a/packages/project/docs/modules/v4_specification.md
+++ b/packages/project/docs/modules/v4_specification.md
@@ -6,7 +6,7 @@
 
 Nori croplands project import file format.
 
-Version: 4.1.0
+Version: 4.2.0
 
 Provides the definitions for Nori croplands project data import using typescript interfaces.
 
@@ -78,7 +78,7 @@ You can find definitions for all of the interfaces in Nori croplands project fro
 
 #### Defined in
 
-[v4-specification.ts:33](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L33)
+[v4-specification.ts:33](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L33)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:123](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L123)
+[v4-specification.ts:123](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L123)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:234](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L234)
+[v4-specification.ts:234](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L234)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:297](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L297)
+[v4-specification.ts:297](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L297)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:176](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L176)
+[v4-specification.ts:176](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L176)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:214](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L214)
+[v4-specification.ts:214](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L214)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:147](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L147)
+[v4-specification.ts:147](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L147)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:260](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L260)
+[v4-specification.ts:260](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L260)
 
 ___
 
@@ -158,4 +158,4 @@ ___
 
 #### Defined in
 
-[v4-specification.ts:155](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/v4-specification.ts#L155)
+[v4-specification.ts:155](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/v4-specification.ts#L155)

--- a/packages/project/docs/modules/validation.md
+++ b/packages/project/docs/modules/validation.md
@@ -43,4 +43,4 @@ validateProjectData(data); // returns {valid:false, ...errors}
 
 #### Defined in
 
-[validation.ts:81](https://github.com/nori-dot-eco/nori-dot-com/blob/1017fe3/packages/project/src/validation.ts#L81)
+[validation.ts:81](https://github.com/nori-dot-eco/nori-dot-com/blob/d0f545e/packages/project/src/validation.ts#L81)

--- a/packages/project/src/json/v4-specification.json
+++ b/packages/project/src/json/v4-specification.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.nori.com/soil/4-0-7",
+    "$id": "https://schema.nori.com/soil/4-2-0",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
@@ -532,6 +532,7 @@
                     "description": "Flag indicating whether data is historical data reported by the grower,\nor a projection of future data.",
                     "enum": [
                         "grower reported",
+                        "historical extrapolation",
                         "projected"
                     ],
                     "title": "dataSourceType",
@@ -586,12 +587,10 @@
                     ]
                 },
                 "lbsOfNPerAcre": {
+                    "default": 0,
                     "description": "Amount of nitrogen applied in lbs/ac.",
                     "title": "lbsOfNPerAcre",
-                    "type": [
-                        "number",
-                        "null"
-                    ]
+                    "type": "number"
                 },
                 "name": {
                     "description": "The name/alias that the fertilizer is known by. This property is used in the to-be-deprecated supplier intake sheet.",

--- a/packages/project/src/v4-specification.ts
+++ b/packages/project/src/v4-specification.ts
@@ -3,7 +3,7 @@
  *
  * Nori croplands project import file format.
  *
- * Version: 4.1.0
+ * Version: 4.2.0
  *
  * Provides the definitions for Nori croplands project data import using typescript interfaces.
  *
@@ -307,13 +307,13 @@ export const limingTypes = [
  * A project may represent either a complete farming operation for a single operator or a batch
  * of fields from a data aggregator.
  *
- * @$id https://schema.nori.com/soil/4-0-7
+ * @$id https://schema.nori.com/soil/4-2-0
  *
- * @example <caption>A project that uses specification v4.1.0 and contains a list of fields:</caption>
+ * @example <caption>A project that uses specification v4.2.0 and contains a list of fields:</caption>
  *
  * ```js
  * {
- *  "version": "4.1.0",
+ *  "version": "4.2.0",
  *  "fields": [
  *    ...fields
  *  ]
@@ -339,7 +339,7 @@ export interface Project {
    * @example
    *
    * ```js
-   * "version": "4.1.0"
+   * "version": "4.2.0"
    * ```
    *
    */
@@ -1176,7 +1176,7 @@ export interface Field {
  *  "crops": [
  *    // ... crops that were planted in year 2000
  *  ],
- *  "dataSourceType": "GROWER_REPORTED",
+ *  "dataSourceType": "grower reported",
  * }
  * ```
  *
@@ -1231,14 +1231,20 @@ export interface CropYear {
    *
    * @default grower reported
    *
-   * @example <caption>When data is from a projection of future data:</caption>
+   * @example <caption>When data is from a projection of anticipated future practice:</caption>
    *
    * ```js
    * "dataSourceType": "projected"
    * ```
+   * @example <caption>When historical data is extrapolated back based on more recent practice data:</caption>
+   *
+   * ```js
+   * "dataSourceType": "historical extrapolation"
+   * ```
+   *
    *
    */
-  dataSourceType?: 'grower reported' | 'projected';
+  dataSourceType?: 'grower reported' | 'projected' | 'historical extrapolation';
 }
 
 /**
@@ -2008,7 +2014,7 @@ export interface FertilizerEvent extends CropEvent {
   /**
    * Amount of nitrogen applied in lbs/ac.
    *
-   * @nullable during import (specify null if you are unsure)
+   * @default 0
    *
    * @example <caption>When 10 lbs of Nitrogen per acre was applied:</caption>
    *


### PR DESCRIPTION
# v4.2.0 (November 28, 2022)
* Added `historical extrapolation` as an option to `CropYear.dataSourceType`.
* Removed nullable annotation from `FertilizerEvent.lbsOfNPerAcre` and applied a schema-level default of 0 to that field.