### PR TITLE
Added a cli script entrypoint to the quantification logic.

### DIFF
--- a/packages/quantification/README.md
+++ b/packages/quantification/README.md
@@ -7,3 +7,25 @@ Quantification utilities
 ```ts
 import { getQuantificationSummary } from '@nori-dot-com/quantification';
 ```
+
+## CLI Usage
+
+### Setup
+```sh
+$ yarn install
+```
+
+### For a multi-field results file.
+
+```sh
+
+$ yarn quantify multi results.json --maxGrandfatherableYears 4
+```
+
+### For an older single-field results file.
+
+i.e. one that may have multiple polygons from the same boundary split out and run as separate fields.
+
+```sh
+$ yarn quantify single results.json --maxGrandfatherableYears 4
+```

--- a/packages/quantification/package.json
+++ b/packages/quantification/package.json
@@ -25,7 +25,8 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "prepare": "tsc -b",
     "watch": "tsc -b -w",
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "quantify": "ts-node src/scripts/cli.ts"
   },
   "bugs": {
     "url": "https://github.com/nori-dot-eco/nori-dot-com/issues"
@@ -33,5 +34,8 @@
   "dependencies": {
     "@nori-dot-com/ggit": "^1.6.0",
     "@nori-dot-com/math": "^1.6.0"
+  },
+  "devDependencies": {
+    "@types/yargs": "^17.0.17"
   }
 }

--- a/packages/quantification/src/scripts/cli.ts
+++ b/packages/quantification/src/scripts/cli.ts
@@ -28,8 +28,6 @@ yargs
     'Runs Nori quantification logic on a multi-field (i.e. python) results file.',
     quantificationArgs,
     async (argv) => {
-      console.log(`Quantifying ${argv.input}`);
-      console.log(JSON.stringify(argv));
       const data = fs.readFileSync(argv.input as string, 'utf8');
       const results = await getQuantificationSummaries({
         data: JSON.parse(data),
@@ -50,8 +48,6 @@ yargs
       });
     },
     async (argv) => {
-      console.log(`Quantifying ${argv.input}`);
-      console.log(JSON.stringify(argv));
       const data = fs.readFileSync(argv.input as string, 'utf8');
       const results = await getQuantificationSummary({
         data: JSON.parse(data),

--- a/packages/quantification/src/scripts/cli.ts
+++ b/packages/quantification/src/scripts/cli.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env ts-node
+
+import {
+  getQuantificationSummaries,
+  getQuantificationSummary,
+} from '../quantification';
+import * as yargs from 'yargs';
+import * as fs from 'fs';
+
+const quantificationArgs = (yargs: yargs.Argv<{}>): yargs.Argv<{}> => {
+  yargs.positional('input', {
+    type: 'string',
+    describe: 'the soil metrics output file',
+  });
+  yargs.options('maxGrandfatherableYears', {
+    type: 'number',
+    default: 4,
+    describe: 'maximum number of grandfatherable years for the project.',
+  });
+  return yargs;
+};
+
+yargs
+  .scriptName('quantify')
+  .usage('$0 <cmd> [args]')
+  .command(
+    'multi [input]',
+    'Runs Nori quantification logic on a multi-field (i.e. python) results file.',
+    quantificationArgs,
+    async (argv) => {
+      console.log(`Quantifying ${argv.input}`);
+      console.log(JSON.stringify(argv));
+      const data = fs.readFileSync(argv.input as string, 'utf8');
+      const results = await getQuantificationSummaries({
+        data: JSON.parse(data),
+        maxNumberGrandfatheredYearsForProject:
+          argv.maxGrandfatherableYears as number,
+      });
+      console.log(JSON.stringify(results, null, 4));
+    }
+  )
+  .command(
+    'single [input]',
+    'Runs Nori quantification logic on a single-field (i.e. sheets) results file.',
+    (yargs) => {
+      quantificationArgs(yargs).options('quantifyAsOfYear', {
+        type: 'number',
+        describe:
+          'Force the year to grandfather as of. Defaults to the current year',
+      });
+    },
+    async (argv) => {
+      console.log(`Quantifying ${argv.input}`);
+      console.log(JSON.stringify(argv));
+      const data = fs.readFileSync(argv.input as string, 'utf8');
+      const results = await getQuantificationSummary({
+        data: JSON.parse(data),
+        maxNumberGrandfatheredYearsForProject:
+          argv.maxGrandfatherableYears as number,
+        quantifyAsOfYear: argv.quantifyAsOfYear as number,
+      });
+      console.log(JSON.stringify(results, null, 4));
+    }
+  )
+  .demandCommand(2)
+  .strict()
+  .help().argv;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,6 +2402,13 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
+"@types/yargs@^17.0.17":
+  version "17.0.17"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.17.tgz#5672e5621f8e0fca13f433a8017aae4b7a2a03e7"
+  integrity sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@types/yargs@^17.0.8":
   version "17.0.13"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.13.tgz#34cced675ca1b1d51fcf4d34c3c6f0fa142a5c76"


### PR DESCRIPTION
Usage i.e. `yarn quantify single ~/Downloads/results_cornsoy_v406.json --maxGrandfatherableYears 4`

```
yarn quantify single --help                                                           
yarn run v1.22.19
$ ts-node src/scripts/cli.ts single --help
quantify single [input]

Runs Nori quantification logic on a single-field (i.e. sheets) results file.

Positionals:
  input  the soil metrics output file                                   [string]

Options:
  --version                  Show version number                       [boolean]
  --help                     Show help                                 [boolean]
  --maxGrandfatherableYears  maximum number of grandfatherable years for the
                             project.                      [number] [default: 4]
  --quantifyAsOfYear         Force the year to grandfather as of. Defaults to
                             the current year                           [number]
✨  Done in 1.73s.

```

```
yarn quantify multi --help 
yarn run v1.22.19
$ ts-node src/scripts/cli.ts multi --help
quantify multi [input]

Runs Nori quantification logic on a multi-field (i.e. python) results file.

Positionals:
  input  the soil metrics output file                                   [string]

Options:
  --version                  Show version number                       [boolean]
  --help                     Show help                                 [boolean]
  --maxGrandfatherableYears  maximum number of grandfatherable years for the
                             project.                      [number] [default: 4]
✨  Done in 1.65s.
```

Example output:

```
{
    "modeledYears": [
        2012,
        2013,
        2014,
        2015,
        2016,
        2017,
        2018,
        2019,
        2020,
        2021
    ],
    "tenYearProjectedTonnesTotalEstimate": 1321.693,
    "somscAnnualDifferencesBetweenFutureAndBaselineScenariosAverage": 161.94767530541057,
    "tenYearProjectedTonnesPerYear": 132.1693,
    "tenYearProjectedTonnesPerYearPerAcre": 0.7318848956459569,
    "somscAnnualDifferencesBetweenFutureAndBaselineScenariosPerPolygon": [
        {
            "2012": -110.81615229972304,
            "2013": 53.527751745875044,
            "2014": 132.95215893933008,
            "2015": 150.7873250192227,
            "2016": 123.88385195323225,
            "2017": -25.4103063943649,
            "2018": 184.9956356225581,
            "2019": 106.22203307834518,
            "2020": 164.10148428019957,
            "2021": -44.168188816777345
        },
        {
            "2012": 0.5258468571388359,
            "2013": -5.1835792658702395,
            "2014": 4.7490877531681335,
            "2015": 7.747216675435475,
            "2016": 8.26058376873098,
            "2017": 12.675552032674942,
            "2018": 12.5606144385254,
            "2019": 11.198154691164232,
            "2020": 6.765103805439222,
            "2021": 17.636739880365106
        }
    ],
    "somscAnnualDifferencesBetweenFutureAndBaselineScenarios": {
        "2018": 197.5562500610835,
        "2019": 117.42018776950941,
        "2020": 170.8665880856388
    },
    "grandfatherableYears": [
        2018,
        2019,
        2020
    ],
    "grandfatheredTonnes": 381.7587877695094,
    "unadjustedGrandfatheredTonnesPerYear": {
        "2018": {
            "amount": 132.1693,
            "method": "projection",
            "averagePerAcre": 0.7318848956459569,
            "totalAcres": 180.5875497448929
        },
        "2019": {
            "amount": 117.42018776950941,
            "method": "somsc",
            "averagePerAcre": 0.6502119771566927,
            "totalAcres": 180.5875497448929
        },
        "2020": {
            "amount": 132.1693,
            "method": "projection",
            "averagePerAcre": 0.7318848956459569,
            "totalAcres": 180.5875497448929
        }
    },
    "tenYearProjectedFutureTonnesPerYear": 155.489,
    "tenYearProjectedFutureTonnesPerYearPerAcre": 0.8610172751092289,
    "tenYearProjectedBaselineTonnesPerYear": 23.3197,
    "tenYearProjectedBaselineTonnesPerYearPerAcre": 0.12913237946327188,
    "totalM2": 730811.8854905855,
    "totalAcres": 180.5875497448929,
    "numberOfGrandfatheredYears": 4,
    "switchYear": 2018,
    "grandfatheredTonnesPerYearPerAcreAverage": 0.5284954421121516,
    "methodologyVersion": "1.0.0"
}
```