### PR TITLE
allow using "_" for variable names

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -204,6 +204,9 @@ module.exports = {
               'UPPER_CASE',
               'PascalCase', // todo remove PascalCase
             ],
+            custom: {
+                regex: '^_$',
+                match: true
           },
           { selector: 'typeLike', format: ['PascalCase'] },
           {


### PR DESCRIPTION
This PR updates our eslint config to allow variables named "_"