### PR TITLE
eslint allow underscore

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -204,6 +204,9 @@ module.exports = {
               'UPPER_CASE',
               'PascalCase', // todo remove PascalCase
             ],
+            custom: {
+                regex: '^_$',
+                match: true
           },
           { selector: 'typeLike', format: ['PascalCase'] },
           {

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -194,7 +194,7 @@ module.exports = {
           'error',
           { selector: 'class', format: ['PascalCase'] },
           {
-            selector: ['function', 'parameter'],
+            selector: ['function'],
             format: ['camelCase', 'UPPER_CASE'],
           },
           {
@@ -204,10 +204,6 @@ module.exports = {
               'UPPER_CASE',
               'PascalCase', // todo remove PascalCase
             ],
-            custom: {
-              regex: '^_$',
-              match: true,
-            },
           },
           { selector: 'typeLike', format: ['PascalCase'] },
           {
@@ -217,7 +213,7 @@ module.exports = {
           },
           {
             selector: ['parameter'],
-            format: ['camelCase'],
+            format: ['camelCase', 'UPPER_CASE'],
             leadingUnderscore: 'allow',
           },
           {

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -214,6 +214,11 @@ module.exports = {
           {
             selector: ['parameter'],
             format: ['camelCase'],
+          },
+          {
+            selector: ['parameter'],
+            format: ['camelCase'],
+            modifiers: ['unused'],
             leadingUnderscore: 'allow',
           },
           {

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -213,9 +213,9 @@ module.exports = {
           },
           {
             selector: ['parameter'],
-            format: ['camelCase'],
             custom: {
-              regex: '^_[a-zA-Z][a-zA-Z0-9]*$',
+              regex: '^_?[a-zA-Z][a-zA-Z0-9]*$',
+              match: true,
             },
           },
           {

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -205,8 +205,9 @@ module.exports = {
               'PascalCase', // todo remove PascalCase
             ],
             custom: {
-                regex: '^_$',
-                match: true
+              regex: '^_$',
+              match: true,
+            },
           },
           { selector: 'typeLike', format: ['PascalCase'] },
           {

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -214,9 +214,13 @@ module.exports = {
           {
             selector: ['parameter'],
             custom: {
-              regex: '^_?[a-zA-Z][a-zA-Z0-9]*$',
+              regex: '^_[a-z][a-zA-Z0-9]*$',
               match: true,
             },
+          },
+          {
+            selector: ['parameter'],
+            format: ['camelCase'],
           },
           {
             selector: ['parameter'],

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -213,7 +213,7 @@ module.exports = {
           },
           {
             selector: ['parameter'],
-            format: ['camelCase', 'UPPER_CASE'],
+            format: ['camelCase'],
             leadingUnderscore: 'allow',
           },
           {

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -214,6 +214,9 @@ module.exports = {
           {
             selector: ['parameter'],
             format: ['camelCase'],
+            custom: {
+              regex: '^_[a-zA-Z][a-zA-Z0-9]*$',
+            },
           },
           {
             selector: ['parameter'],


### PR DESCRIPTION
This PR updates the rules affecting function parameters

Prior to this change we would see this error message, showing that parameters need to match the `[ 'function', 'parameter' ]` condition (no underscore prefixes), in addition to the existing rule for parameters, which does allow underscores / underscore prefixes.

Prior to this change, here's an example eslint error:
<img width="940" alt="image" src="https://user-images.githubusercontent.com/7808563/213571971-e33f9b24-0e3e-40de-85f0-f5049dd58db0.png">

After this change, the error is no longer showing:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/7808563/213572223-d38790a2-3a24-44c0-b913-94bad0696c19.png">
