### PR TITLE
All eslint rules only warn

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -309,4 +309,5 @@ module.exports = {
       files: ['*.toml'],
     },
   ],
+  plugins: ['only-warn'],
 };

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -308,6 +308,9 @@ module.exports = {
       extends: ['airbnb-base', 'plugin:toml/standard'],
       files: ['*.toml'],
     },
+    {
+      files: ['*'],
+      plugins: ['only-warn'],
+    }
   ],
-  plugins: ['only-warn'],
 };

--- a/packages/eslint-config-nori/package.json
+++ b/packages/eslint-config-nori/package.json
@@ -31,7 +31,6 @@
     "react-dom": "~17"
   },
   "dependencies": {
-    "eslint-plugin-md": "1.0.19",
     "@fintechstudios/eslint-plugin-chai-as-promised": "3.1.0",
     "@graphql-eslint/eslint-plugin": "^3.13.1",
     "@next/eslint-plugin-next": "^12.1.6",
@@ -53,7 +52,9 @@
     "eslint-plugin-jsdoc": "^39.2.9",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-local-rules": "^1.3.0",
+    "eslint-plugin-md": "1.0.19",
     "eslint-plugin-mui-unused-classes": "^1.0.3",
+    "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4285,6 +4285,11 @@ eslint-plugin-mui-unused-classes@^1.0.3:
   resolved "https://registry.yarnpkg.com/eslint-plugin-mui-unused-classes/-/eslint-plugin-mui-unused-classes-1.0.3.tgz#5601c17ac6094b36452117fe84792eeaaddc23a8"
   integrity sha512-hsvoxxcL189LSyUyBvak+tK7XHKvoAiUBQpnCRyx6hLf4FTE+WWNtE9cRwcUwZvdh+E/wLHGp9JpNveQcQpUTw==
 
+eslint-plugin-only-warn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.1.0.tgz#c6ddc37ddc4e72c121f07be565fcb7b6671fe78a"
+  integrity sha512-2tktqUAT+Q3hCAU0iSf4xAN1k9zOpjK5WO8104mB0rT/dGhOa09582HN5HlbxNbPRZ0THV7nLGvzugcNOSjzfA==
+
 eslint-plugin-prettier@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"


### PR DESCRIPTION
Developers are ignoring test suites because eslint is causing every build's overall status check to go red. We don't want to lose the information eslint is giving us, but we're not prepared to fix all eslint issues. 

This PR sets all rules to warn, such that we can have better signals for when tests break. 