### PR TITLE
add cypress eslint config

### DIFF
--- a/packages/eslint-config-nori/cypress.js
+++ b/packages/eslint-config-nori/cypress.js
@@ -25,7 +25,7 @@ module.exports = {
           {
             allowPattern: '^[A-Z]+', // allow upper pascal cased index access (e.g., allows process.env['NODE_ENV'])
           },
-        ], // this package uses a strict set of tsconfig that uses noPropertyAccessFromIndexSignature which can break this rule
+        ],
         'no-unused-expressions': 0, // https://github.com/cypress-io/eslint-plugin-cypress#chai-and-no-unused-expressions
         'chai-friendly/no-unused-expressions': 'error', // https://github.com/cypress-io/eslint-plugin-cypress#chai-and-no-unused-expressions
       },

--- a/packages/eslint-config-nori/cypress.js
+++ b/packages/eslint-config-nori/cypress.js
@@ -1,5 +1,3 @@
-const { importRules } = require('./rules');
-
 module.exports = {
   extends: '@nori-dot-com/eslint-config-nori',
   overrides: [
@@ -9,9 +7,8 @@ module.exports = {
         'plugin:cypress/recommended',
         'plugin:chai-friendly/recommended',
       ],
-      processor: '@graphql-eslint/graphql', // todo merge with following overrides block?
+      processor: '@graphql-eslint/graphql',
       rules: {
-        ...importRules({ dir: __dirname }),
         'cypress/no-force': 'error',
         'cypress/assertion-before-screenshot': 'error',
         'cypress/require-data-selectors': 'error',

--- a/packages/eslint-config-nori/cypress.js
+++ b/packages/eslint-config-nori/cypress.js
@@ -1,0 +1,37 @@
+const { importRules } = require('./rules');
+
+module.exports = {
+  extends: '@nori-dot-com/eslint-config-nori',
+  overrides: [
+    {
+      files: ['**/src/**/*.ts'],
+      extends: [
+        'plugin:cypress/recommended',
+        'plugin:chai-friendly/recommended',
+      ],
+      processor: '@graphql-eslint/graphql', // todo merge with following overrides block?
+      rules: {
+        ...importRules({ dir: __dirname }),
+        'cypress/no-force': 'error',
+        'cypress/assertion-before-screenshot': 'error',
+        'cypress/require-data-selectors': 'error',
+        'cypress/no-pause': 'error',
+        'jest/expect-expect': ['off'],
+        'jest/valid-expect-in-promise': ['off'],
+        'jest/valid-expect': ['off'],
+        'jest/no-standalone-expect': ['off'],
+        'no-useless-constructor': ['off'],
+        'unicorn/consistent-function-scoping': ['off'], // defining a function in the top scope of a test file makes the function global
+        'jest/valid-describe-callback': ['off'], // cypress-grep uses a different implementation for describe blocks
+        'dot-notation': [
+          'warn',
+          {
+            allowPattern: '^[A-Z]+', // allow upper pascal cased index access (e.g., allows process.env['NODE_ENV'])
+          },
+        ], // this package uses a strict set of tsconfig that uses noPropertyAccessFromIndexSignature which can break this rule
+        'no-unused-expressions': 0, // https://github.com/cypress-io/eslint-plugin-cypress#chai-and-no-unused-expressions
+        'chai-friendly/no-unused-expressions': 'error', // https://github.com/cypress-io/eslint-plugin-cypress#chai-and-no-unused-expressions
+      },
+    },
+  ],
+};

--- a/packages/eslint-config-nori/package.json
+++ b/packages/eslint-config-nori/package.json
@@ -14,7 +14,8 @@
     "package.json",
     "rules.js",
     "eslint-local-rules/index.js",
-    "eslint-local-rules/waffle-as-promised.js"
+    "eslint-local-rules/waffle-as-promised.js",
+    "cypress.js"
   ],
   "repository": {
     "type": "git",
@@ -46,6 +47,7 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-chai-expect": "^3.0.0",
     "eslint-plugin-chai-friendly": "^0.7.2",
+    "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4213,6 +4213,13 @@ eslint-plugin-chai-friendly@^0.7.2:
   resolved "https://registry.yarnpkg.com/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.2.tgz#0ebfbb2c1244f5de2997f3963d155758234f2b0f"
   integrity sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg==
 
+eslint-plugin-cypress@^2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"
+  integrity sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==
+  dependencies:
+    globals "^11.12.0"
+
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
@@ -5234,7 +5241,7 @@ globals@^11.1.0:
   resolved "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
   integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
 
-globals@^11.7.0:
+globals@^11.12.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==


### PR DESCRIPTION
Changelog:
- Add the [cypress eslint plugin](https://www.npmjs.com/package/eslint-plugin-cypress) and enables all rules
- expose a new base ruleset that can be reused in cypress packages `@nori-dot-com/eslint-config-nori/cypress`

---

Usage example [here](https://github.com/nori-dot-eco/nori/pull/3430/files#diff-6bbf7590b3dbbcb763d6cb06f73f2ca5e4ce31a03476d7d0083b063954dbe5ffR1-R11)