### PR TITLE
Updating the package publishing configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,8 @@ jobs:
             do
               export PACKAGE=$PACKAGE;
               echo "Publishing $PACKAGE...";
-              CURRENT_VERSION=$(yarn workspace $PACKAGE versions --json | sed '$d' | tail -n +2 | jq -r '.data[env.PACKAGE]');
-              yarn workspace $PACKAGE publish --new-version $CURRENT_VERSION;
+              PACKAGE_PATH=$(yarn workspaces info --json  | sed '$d' | tail -n +2 | jq -r '.[env.PACKAGE].location');
+              (cd $PACKAGE_PATH && npm publish);
             done
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,12 +136,13 @@ jobs:
           name: Publishing Packages
           command: |
             echo "Publishing packages...";
+            TARGET_REGISTRY="https://us-central1-npm.pkg.dev/nori-internal/npm-release/";
             for PACKAGE in $(cat /tmp/packages_to_publish);
             do
               export PACKAGE=$PACKAGE;
               echo "Publishing $PACKAGE...";
-              PACKAGE_PATH=$(yarn workspaces info --json  | sed '$d' | tail -n +2 | jq -r '.[env.PACKAGE].location');
-              (cd $PACKAGE_PATH && npm publish);
+              CURRENT_VERSION=$(yarn workspace $PACKAGE versions --json | sed '$d' | tail -n +2 | jq -r '.data[env.PACKAGE]');
+              yarn workspace $PACKAGE publish --new-version $CURRENT_VERSION --registry $TARGET_REGISTRY;
             done
 
 workflows:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "name": "nori-dot-com",
   "devDependencies": {

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/cspell",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "custom cspell dictionary",
   "keywords": [
     "cspell"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/errors",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Errors and error messaging for Nori",
   "author": "jaycenhorton <jaycen@nori.com>",
   "homepage": "https://github.com/nori-dot-eco/nori-dot-com#readme",

--- a/packages/eslint-config-nori/package.json
+++ b/packages/eslint-config-nori/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/eslint-config-nori",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "eslint config for Nori",
   "keywords": [
     "eslint"

--- a/packages/ggit/package.json
+++ b/packages/ggit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/ggit",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "utilities for interacting with the Soil Metrics GGIT API",
   "keywords": [
     "nori",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/math",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Math utilities",
   "author": "jaycenhorton <jaycen@nori.com>",
   "homepage": "https://github.com/nori-dot-eco/nori-dot-com#readme",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/project",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Nori supplier project specification and utilities",
   "keywords": [
     "nori"

--- a/packages/quantification/package.json
+++ b/packages/quantification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/quantification",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "utilities for quantifying Nori's soil methodology based projects",
   "keywords": [
     "nori",


### PR DESCRIPTION
When updating consumers of these packages to pull from artifact registry, I found that the package metadata was corrupted. This PR solves that issue, and bumps the package versions so that a new, usable version of these packages is available

This happens because yarn 1.x is not able to properly parse scoped npm registry configurations ([ex - configuring a registry for packages under the @nori-dot-com scope](https://github.com/nori-dot-eco/nori-dot-com/blob/master/.npmrc#L1)). While yarn was publishing to the correct registry, it improperly continued to refer to the default publicly registry from the package metadata (screenshot for quantification below)
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/7808563/226456203-8352c532-4a46-4c44-8f56-6b965bb7d07e.png">

After testing change included in this PR, I verified that the metadata include with packages is valid. 

