### PR TITLE
Add importJobId to data-spec

### DIFF
--- a/packages/project/src/json/v4-specification.json
+++ b/packages/project/src/json/v4-specification.json
@@ -721,7 +721,7 @@
                             "$ref": "#/definitions/GeoJSON.MultiPolygon"
                         },
                         {
-                            "$ref": "#/definitions/GeoJSON.GeometryCollection<GeoJSON.Geometry>"
+                            "$ref": "#/definitions/GeoJSON.GeometryCollection"
                         },
                         {
                             "$ref": "#/definitions/GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>"
@@ -912,7 +912,7 @@
                             "$ref": "#/definitions/GeoJSON.MultiPolygon"
                         },
                         {
-                            "$ref": "#/definitions/GeoJSON.GeometryCollection<GeoJSON.Geometry>"
+                            "$ref": "#/definitions/GeoJSON.GeometryCollection"
                         }
                     ],
                     "description": "The feature's geometry",
@@ -1031,7 +1031,7 @@
                             "$ref": "#/definitions/GeoJSON.MultiPolygon"
                         },
                         {
-                            "$ref": "#/definitions/GeoJSON.GeometryCollection<GeoJSON.Geometry>"
+                            "$ref": "#/definitions/GeoJSON.GeometryCollection"
                         }
                     ],
                     "description": "The feature's geometry",
@@ -1152,7 +1152,7 @@
             "title": "GeoJSON.FeatureCollection<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>",
             "type": "object"
         },
-        "GeoJSON.GeometryCollection<GeoJSON.Geometry>": {
+        "GeoJSON.GeometryCollection": {
             "additionalProperties": false,
             "description": "Geometry Collection\nhttps://tools.ietf.org/html/rfc7946#section-3.1.8",
             "properties": {
@@ -1228,7 +1228,7 @@
                                 "$ref": "#/definitions/GeoJSON.MultiPolygon"
                             },
                             {
-                                "$ref": "#/definitions/GeoJSON.GeometryCollection<GeoJSON.Geometry>"
+                                "$ref": "#/definitions/GeoJSON.GeometryCollection"
                             }
                         ],
                         "description": "Geometry object.\nhttps://tools.ietf.org/html/rfc7946#section-3"
@@ -1249,7 +1249,7 @@
                 "geometries",
                 "type"
             ],
-            "title": "GeoJSON.GeometryCollection<GeoJSON.Geometry>",
+            "title": "GeoJSON.GeometryCollection",
             "type": "object"
         },
         "GeoJSON.LineString": {
@@ -2628,6 +2628,14 @@
         "id": {
             "description": "Nori's internal project identifier.\n\nUsed to synchronize repeated imports.",
             "title": "id",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "importJobId": {
+            "description": "Nori's internal identifier for the entity associated\nwith the import of this project",
+            "title": "importJobId",
             "type": [
                 "string",
                 "null"

--- a/packages/project/src/v4-specification.ts
+++ b/packages/project/src/v4-specification.ts
@@ -413,6 +413,20 @@ export interface Project {
    */
   id?: string;
   /**
+   * Nori's internal identifier for the entity associated
+   * with the import of this project
+   *
+   * @nullable External systems pass null or omit the property for new projects.
+   *
+   * @example
+   *
+   * ```js
+   * "id": "faec5e0b-8ce2-4161-93ff-4c9734f22334"
+   * ```
+   *
+   */
+  importJobId?: string;
+  /**
    * Nori's internal supplier identifier.
    *
    * Used to correlate projects / batches to a supplier.

--- a/packages/project/src/v4-specification.ts
+++ b/packages/project/src/v4-specification.ts
@@ -413,19 +413,18 @@ export interface Project {
    */
   id?: string;
   /**
-   * Nori's internal identifier for the entity associated
-   * with the import of this project
+   * Nori's internal identifier for this project's import transaction.
    *
    * @nullable External systems pass null or omit the property for new projects.
    *
    * @example
    *
    * ```js
-   * "id": "faec5e0b-8ce2-4161-93ff-4c9734f22334"
+   * "transactionId": "faec5e0b-8ce2-4161-93ff-4c9734f22334"
    * ```
    *
    */
-  importJobId?: string;
+  transactionId?: string;
   /**
    * Nori's internal supplier identifier.
    *


### PR DESCRIPTION
Adding the `importJobId` to the data spec as part of [this ticket](https://norinauts.atlassian.net/jira/software/c/projects/NO/boards/1?modal=detail&selectedIssue=NO-2909&sprint=52&quickFilter=5).

Tried to keep the implementation details out of the spec, so have simply called it `transactionId`.  @scottynomad - should I keep it simple and just call it `importJobId`?