### PR TITLE
Updating nori-dot-com pipeline to use new nori orb for publishing packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   gcp-cli: circleci/gcp-cli@3.0.1
+  nori-package-management-orb: nori-dot-com/nori-package-management-orb@0.0.1
 
 defaults: &defaults
   working_directory: ~/repo
@@ -20,20 +21,6 @@ commands:
             echo 'export PATH=$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH' >> $BASH_ENV;
             git config --global user.email "circleci@nori.com";
             git config --global user.name "Circle CI";
-  auth-gcloud:
-    description: 'Authenticate with google cloud'
-    steps:
-      - gcp-cli/install
-      - run:
-          name: Authenticate with gcloud
-          command: |
-            sudo mkdir -p /var/secrets/google;
-            sudo chown -R circleci:circleci /var/secrets/google;
-            echo $NORI_INTERNAL_SERVICE_KEY > /var/secrets/google/key.json;
-            echo 'export GOOGLE_APPLICATION_CREDENTIALS=/var/secrets/google/key.json' >> $BASH_ENV;
-
-            gcloud auth activate-service-account --key-file /var/secrets/google/key.json;
-            gcloud config set project nori-internal;
 
 jobs:  
   setup-tests:
@@ -96,55 +83,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
-      - setup-environment
-      - auth-gcloud
-      - run:
-          name: Checking for Existing Packages
-          command: |
-            echo "Configuring registry auth...";
-            touch ~/.npmrc;
-            yarn run artifactregistry-login;
-
-            WORKSPACE_PACKAGES=( $(yarn workspaces info --json | sed '$d' | tail -n +2 | jq -r 'keys | join(" ")') );
-
-            echo "Detecting existing packages...";
-
-            touch /tmp/packages_to_publish;
-            for PACKAGE in ${WORKSPACE_PACKAGES[@]};
-            do
-              export PACKAGE=$PACKAGE
-              export CURRENT_VERSION=$(yarn workspace $PACKAGE versions --json | sed '$d' | tail -n +2 | jq -r '.data[env.PACKAGE]');
-
-              VERSION_EXISTS=$(
-                gcloud artifacts versions list \
-                  --location us-central1 \
-                  --repository npm-release \
-                  --package=$PACKAGE \
-                  --format json | jq \
-                    '[.[].name | capture(".*/versions/(?<version>.*)").version | contains(env.CURRENT_VERSION)] 
-                    | max'
-              );
-
-              if [[ "$VERSION_EXISTS" = "false" ]]; then
-                echo $PACKAGE >> /tmp/packages_to_publish;
-              fi
-            done
-
-            echo "Identified packages to publish:";
-            cat /tmp/packages_to_publish;
-      - run:
-          name: Publishing Packages
-          command: |
-            echo "Publishing packages...";
-            TARGET_REGISTRY="https://us-central1-npm.pkg.dev/nori-internal/npm-release/";
-            for PACKAGE in $(cat /tmp/packages_to_publish);
-            do
-              export PACKAGE=$PACKAGE;
-              echo "Publishing $PACKAGE...";
-              CURRENT_VERSION=$(yarn workspace $PACKAGE versions --json | sed '$d' | tail -n +2 | jq -r '.data[env.PACKAGE]');
-              yarn workspace $PACKAGE publish --new-version $CURRENT_VERSION --registry $TARGET_REGISTRY;
-            done
-
+      - nori-package-management-orb/publish-packages
 workflows:
   continuous-integration:
     jobs:


### PR DESCRIPTION
This change simplifies the publishing logic by referencing a [reusable orb](https://github.com/nori-dot-eco/nori-infrastructure/tree/master/circleci/orbs/nori-package-management-orb) containing publishing logic