### PR TITLE
Use single line option for unicorn/prefer-ternary

### DIFF
--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -75,6 +75,7 @@ module.exports = {
         'unicorn/prefer-switch': [0],
         'unicorn/no-useless-undefined': [0],
         'unicorn/prefer-node-protocol': [0], // todo enable this when we have a compatible version of node (~18)
+        'unicorn/prefer-ternary': ['error', 'only-single-line'],
         // 'unicorn/filename-case': [ // todo enable this after running kebab-case codemod to rename files
         //   'warn',
         //   {


### PR DESCRIPTION
Currently our linter can turn things like
```
    if (isReimport) {
      await reimportProject({
        croplandsSpec,
        importJob,
        filePath,
        destinationFolder,
      }, viewerContext);
    } else {
      await importProject({
        croplandsSpec,
        importJob,
        filePath,
        destinationFolder,
        supplier,
      }, viewerContext);
    }
```
into
```
    await (isReimport
      ? reimportProject(
          {
            croplandsSpec,
            importJob,
            filePath,
            destinationFolder,
          },
          viewerContext
        )
      : importProject(
          {
            croplandsSpec,
            importJob,
            filePath,
            destinationFolder,
            supplier,
          },
          viewerContext
        ));
```
which I think is kinda gross. This PR modifies that rule to use the `'only-single-line'` option, which I think is a slightly better behavior. Here's a demo:
![ternary-linter](https://user-images.githubusercontent.com/6805216/226763496-dd950b49-ef16-4f42-99ef-415e64430c18.gif)

