### PR TITLE
emit declaration map for enable go-to-source

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2018",
     "lib": ["esnext", "dom"],
     "declaration": true,
+    "declarationMap": true,
     "composite": true,
     "outDir": "./dist",
     "rootDir": ".",


### PR DESCRIPTION
This emits a `.d.ts.map` [declaration map](https://www.typescriptlang.org/tsconfig#declarationMap) file alongside other declaration files so that when you use "go to implementation" in your IDE it goes to the source code of the nori-dot-com modules instead of the current functionality (which is that it goes to the type declaration files)
