### PR TITLE
Updating package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "version": "1.6.1",
   "private": true,
   "name": "nori-dot-com",
   "devDependencies": {

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/cspell",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "custom cspell dictionary",
   "keywords": [
     "cspell"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/errors",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Errors and error messaging for Nori",
   "author": "jaycenhorton <jaycen@nori.com>",
   "homepage": "https://github.com/nori-dot-eco/nori-dot-com#readme",

--- a/packages/eslint-config-nori/package.json
+++ b/packages/eslint-config-nori/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/eslint-config-nori",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "eslint config for Nori",
   "keywords": [
     "eslint"

--- a/packages/ggit/package.json
+++ b/packages/ggit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/ggit",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "utilities for interacting with the Soil Metrics GGIT API",
   "keywords": [
     "nori",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/math",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Math utilities",
   "author": "jaycenhorton <jaycen@nori.com>",
   "homepage": "https://github.com/nori-dot-eco/nori-dot-com#readme",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/project",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Nori supplier project specification and utilities",
   "keywords": [
     "nori"

--- a/packages/quantification/package.json
+++ b/packages/quantification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-dot-com/quantification",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "utilities for quantifying Nori's soil methodology based projects",
   "keywords": [
     "nori",


### PR DESCRIPTION
This PR updates the versions of the `nori-dot-com` libraries so that new versions are published & available in artifact registry with the latest source-mapping changes

It also removes the version field from the workspace `package.json` - as that version is not required, and doesn't add value IMO