### PR TITLE
NO-2966 - Refactoring the interfaces used for soil metrics errors

### DIFF
--- a/packages/ggit/src/output/output.ts
+++ b/packages/ggit/src/output/output.ts
@@ -48,15 +48,23 @@ export interface OutputFile<M> {
   Day: Daycent<M>;
 }
 
-export type ErrorResponse = InputValidationError | AllErrors;
-
 /**
  *
  * @example
  */
-export interface InputValidationError {
-  InputErrors: {
-    InputValidationErrors: SoilMetricsError;
+export interface ErrorResponse {
+  AllErrors?: {
+    Errors: {
+      ModelRun: ModelRunErrorCollection | ModelRunErrorCollection[];
+    };
+  };
+  InputErrors?: {
+    InputValidationErrors?: {
+      ModelRun: ModelRunErrorCollection | ModelRunErrorCollection[];
+    };
+    APIBuildErrors?: {
+      BuildError: ModelRunErrorCollection | ModelRunErrorCollection[];
+    };
   };
 }
 
@@ -64,34 +72,17 @@ export interface InputValidationError {
  *
  * @example
  */
-export interface AllErrors {
-  AllErrors: {
-    Errors: SoilMetricsError;
-  };
-}
-
-/**
- *
- * @example
- */
-interface SoilMetricsError {
-  ModelRun: ModelRunErrors | ModelRunErrors[];
-}
-
-/**
- *
- * @example
- */
-export interface ModelRunErrors {
+export interface ModelRunErrorCollection {
   '@name': string;
-  Error: Error | Error[];
+  '#text'?: string;
+  Error?: ModelRunError | ModelRunError[];
 }
 
 /**
  *
  * @example
  */
-interface Error {
+interface ModelRunError {
   '@index': string;
   '@message': string;
 }

--- a/packages/ggit/src/output/output.ts
+++ b/packages/ggit/src/output/output.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention -- the naming conventions used here are dictated by an external service  */
 
 /**
  *
@@ -55,7 +55,9 @@ export type ErrorResponse = InputValidationError | AllErrors;
  * @example
  */
 export interface InputValidationError {
-  InputErrors: InputErrors;
+  InputErrors: {
+    InputValidationErrors: SoilMetricsError;
+  };
 }
 
 /**
@@ -64,7 +66,7 @@ export interface InputValidationError {
  */
 export interface AllErrors {
   AllErrors: {
-    Errors: Error;
+    Errors: SoilMetricsError;
   };
 }
 
@@ -72,30 +74,15 @@ export interface AllErrors {
  *
  * @example
  */
-export interface Errors {
-  AllErrors: InputErrors;
-}
-/**
- *
- * @example
- */
-interface InputErrors {
-  InputValidationErrors: Error;
+interface SoilMetricsError {
+  ModelRun: ModelRunErrors | ModelRunErrors[];
 }
 
 /**
  *
  * @example
  */
-interface Error {
-  ModelRun: ModelRunErrors;
-}
-
-/**
- *
- * @example
- */
-interface ModelRunErrors {
+export interface ModelRunErrors {
   '@name': string;
   Error: Error | Error[];
 }


### PR DESCRIPTION
This PR updates the interfaces used for soil metrics errors to expose helpful interfaces, as well as to avoid naming collisions

Here are some sample error response formats that these interfaces need to match: 
```
{
  "AllErrors": {
    "Errors": {
      "ModelRun": {
        "@name": "<name>",
        "Error": {
          "@index": "1",
          "@message": "<Error Message>"
        }
      }
    }
  }
}

{
  "InputErrors": {
    "InputValidationErrors": {
      "ModelRun": {
        "@name": "<name>",
        "Error": {
          "@index": "1",
          "@message": "<Error Message>"
        }
      }
    }
  }
}
```

> _**Note:** I ran these structures by the soil metrics team, and was told the structures defined by this PR's interfaces look generally look right. I haven't gotten official documentation to be 100% confident however_