### PR TITLE
Add `priceOrFeeMismatch` error to checkout errors

### DIFF
--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -252,7 +252,7 @@ export const Errors = {
     },
     priceOrFeeMismatch: {
       message:
-        'The totalPricePerTonneInCents on this order does not match the current on-chain pricing.',
+        'The price for NRTs has changed. Please refresh the page and try again.',
     },
   },
   authenticationError: {

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -250,6 +250,10 @@ export const Errors = {
     specialOrderTransactionInProgress: {
       message: 'A transaction has already been created for this order.',
     },
+    priceOrFeeMismatch: {
+      message:
+        'The totalPricePerTonneInCents on this order does not match the current on-chain pricing.',
+    },
   },
   authenticationError: {
     userNotFound: {


### PR DESCRIPTION
An error for when an order is created but the price or fee data changes on-chain before fulfillment starts.