### PR TITLE
add refetchable to word list, disable known directive lint rule

### DIFF
--- a/packages/cspell/custom-words.txt
+++ b/packages/cspell/custom-words.txt
@@ -201,6 +201,7 @@ query
 ratio
 reddit
 refetch
+refetchable
 registrar
 renderer
 repo

--- a/packages/eslint-config-nori/index.js
+++ b/packages/eslint-config-nori/index.js
@@ -166,6 +166,9 @@ module.exports = {
         'plugin:@graphql-eslint/schema-recommended',
         'plugin:@graphql-eslint/relay',
       ],
+      rules: {
+        '@graphql-eslint/known-directives': 0,
+      },
     },
     {
       files: ['**/*.ts', '**/*.tsx'],


### PR DESCRIPTION
the known directives rule disabled is instead handled automatically by the relay vscode extension. The lint rule could was not able to handle `@argumentDefinitions` causing a false error