### PR TITLE
Updated the automerge dependabot filter

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -20,7 +20,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        if: ${{ (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') || steps.metadata.outputs.update-type == 'indirect'}}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
> Addresses: [NO-3092]

This PR updates the filter that dependabot uses for auto-merging. Previously it was ignoring transitive dependency updates. After this change, transitive dependency updates will be auto-approved / merged (upon CI success). 

> Note: dependabot does not capture metadata around the type of upgrade being proposed for transitive dependencies (patch|minor|major). As a result, transitive dependency upgrades are not being filtered to limit major version bumps

------

[NO-3092]: https://norinauts.atlassian.net/browse/NO-3092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ