### PR TITLE
NO-3092 - Updating dependabot automerge filter

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -20,7 +20,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') || steps.metadata.outputs.update-type == 'indirect'}}
+        if: ${{ (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') || steps.metadata.outputs.dependency-type == 'indirect'}}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
This PR adds another adjustment to the dependabot filter to match the way dependabot classifies indirect dependencies

<img width="566" alt="image" src="https://github.com/nori-dot-eco/nori-dot-com/assets/7808563/6f75d726-0ace-4624-a387-ce3dcd557d1f">
