### PR TITLE
Updating v4 spec to have a required externalId per field

### DIFF
--- a/packages/project/src/__tests__/validation.test.ts
+++ b/packages/project/src/__tests__/validation.test.ts
@@ -17,6 +17,7 @@ const BASIC_UNFORMATTED_VALID_PROJECT: Project = {
   fields: [
     {
       legalAcres: 174.01,
+      externalId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       historicLandManagement: {
         crp: false,
         preYear1980: 'Irrigation',
@@ -109,6 +110,7 @@ const BASIC_UNFORMATTED_INVALID_PROJECT: Project = {
   fields: [
     {
       legalAcres: 174.01,
+      externalId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       historicLandManagement: {
         crp: false,
         preYear1980: 'Irrigation',
@@ -477,6 +479,7 @@ describe('validation', () => {
                 fields: [
                   {
                     legalAcres: 174.01,
+                    externalId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
                     historicLandManagement: null,
                     regenerativeStartYear: 2015,
                     earliestEvidenceYear: 2008,

--- a/packages/project/src/json/v4-specification.json
+++ b/packages/project/src/json/v4-specification.json
@@ -672,12 +672,9 @@
                     "type": "number"
                 },
                 "externalId": {
-                    "description": "Field identifier from external system.\n\nUsed to correlate data back to the originating system and to synchronize repeated imports.",
+                    "description": "Field identifier from external system.\n\nUsed to correlate data back to the originating system and to synchronize repeated imports.\nThis field must be unique within a project.",
                     "title": "externalId",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "farmOperator": {
                     "anyOf": [
@@ -800,6 +797,7 @@
                 "assignmentOfAuthority",
                 "cropYears",
                 "earliestEvidenceYear",
+                "externalId",
                 "fieldName",
                 "geojson",
                 "historicLandManagement",
@@ -1079,7 +1077,7 @@
                     "$ref": "#/definitions/GeoJSON.MultiPolygon"
                 },
                 {
-                    "$ref": "#/definitions/GeoJSON.GeometryCollection<GeoJSON.Geometry>"
+                    "$ref": "#/definitions/GeoJSON.GeometryCollection"
                 },
                 {
                     "$ref": "#/definitions/GeoJSON.Feature<GeoJSON.Geometry,GeoJSON.GeoJsonProperties>"
@@ -1124,13 +1122,13 @@
                     "$ref": "#/definitions/GeoJSON.MultiPolygon"
                 },
                 {
-                    "$ref": "#/definitions/GeoJSON.GeometryCollection<GeoJSON.Geometry>"
+                    "$ref": "#/definitions/GeoJSON.GeometryCollection"
                 }
             ],
             "description": "Geometry object.\nhttps://tools.ietf.org/html/rfc7946#section-3",
             "title": "GeoJSON.Geometry"
         },
-        "GeoJSON.GeometryCollection<GeoJSON.Geometry>": {
+        "GeoJSON.GeometryCollection": {
             "additionalProperties": false,
             "description": "Geometry Collection\nhttps://tools.ietf.org/html/rfc7946#section-3.1.8",
             "properties": {
@@ -1202,7 +1200,7 @@
                 "geometries",
                 "type"
             ],
-            "title": "GeoJSON.GeometryCollection<GeoJSON.Geometry>",
+            "title": "GeoJSON.GeometryCollection",
             "type": "object"
         },
         "GeoJSON.LineString": {

--- a/packages/project/src/utils/convertFromV3ToV4.ts
+++ b/packages/project/src/utils/convertFromV3ToV4.ts
@@ -196,6 +196,7 @@ const convertV3CropToV4Crop = (
 export const convertV3FieldToV4Field = (v3Field: FieldV3): FieldV4 => {
   return {
     ...v3Field,
+    externalId: v3Field.fieldName,
     legalAcres: v3Field.acres,
     assignmentOfAuthority: false,
     historicLandManagement: convertHistoricLandManagement(

--- a/packages/project/src/v4-specification.ts
+++ b/packages/project/src/v4-specification.ts
@@ -1087,15 +1087,15 @@ export interface Field {
    * Field identifier from external system.
    *
    * Used to correlate data back to the originating system and to synchronize repeated imports.
-   *
-   * @nullable
+   * This field must be unique within a project.
+   * 
    * @example
    *
    * ```js
    * "externalId": "faec5e0b-8ce2-4161-93ff-4c9734f22334"
    * ```
    */
-  externalId?: string;
+  externalId: string;
   /**
    * Nori's internal field identifier.
    *


### PR DESCRIPTION
This PR updates our v4 spec to ensure that `externalId` properties are provided within v4 files. This requirement comes from the need to have a reliable unique id per field when performing operations such as "synchronizing repeated reports"