### PR TITLE
Update how annual totals are recorded in the quantification package

### DIFF
--- a/packages/quantification/src/constants.ts
+++ b/packages/quantification/src/constants.ts
@@ -1,3 +1,6 @@
+import { divide } from '@nori-dot-com/math';
+
 export const CURRENT_YEAR = new Date().getFullYear();
 export const METHODOLOGY_VERSION = '1.0.0';
 export const SOIL_METRICS_RESULTS_NAME_SUFFIX = ' : FILE RESULTS';
+export const ATOMIC_WEIGHT_RATIO_OF_CO2_TO_C = divide(44, 12);

--- a/packages/quantification/src/utils.ts
+++ b/packages/quantification/src/utils.ts
@@ -1,5 +1,30 @@
-import { multiply } from '@nori-dot-com/math';
+import { divide, multiply } from '@nori-dot-com/math';
+
+import { ATOMIC_WEIGHT_RATIO_OF_CO2_TO_C } from './constants';
 
 export const convertM2ToAcres = ({ m2 }: { m2: number }): number => {
   return multiply(m2, 0.000_247_105_381_467_17);
+};
+
+/**
+ * Converts grams per meter squared and a map area in meters squared to the total tonnes of CO2e
+ *
+ */
+export const convertGramsPerM2ToTonnes = ({
+  gramsPerM2,
+  mapUnitAreaInM2,
+}: {
+  gramsPerM2: number;
+  mapUnitAreaInM2: number;
+}): number => {
+  const gramsOfCarbonForMapUnitInM2 = multiply(gramsPerM2, mapUnitAreaInM2);
+  const tonnesOfCarbonForMapUnit = divide(
+    gramsOfCarbonForMapUnitInM2,
+    1_000_000 // 1 million
+  );
+  const tonnesOfCO2eForMapUnit = multiply(
+    tonnesOfCarbonForMapUnit,
+    ATOMIC_WEIGHT_RATIO_OF_CO2_TO_C
+  );
+  return tonnesOfCO2eForMapUnit;
 };


### PR DESCRIPTION
To allow SAMs better insights into how the somsc differences were calculated, we should also record the numbers used to generate the differences (IE - the totals for both the future and baseline scenarios).

More work to be done in terms of how this affects how quantification results are consumed by other Nori services, but this at least gives us the opportunity to run the quantification CLI to get these results (since our SAMs need these numbers now).