### PR TITLE
Updating the v4 spec to remove the max gallonsPerAcre for slurry events

### DIFF
--- a/packages/project/src/json/v4-specification.json
+++ b/packages/project/src/json/v4-specification.json
@@ -2479,7 +2479,6 @@
                 },
                 "tonsPerAcre": {
                     "description": "Amount of organic matter or manure applied per acre (in tons per acre for solid/dry organic matter or gallons per acre for slurry).",
-                    "maximum": 200,
                     "minimum": 0,
                     "title": "tonsPerAcre",
                     "type": "number"

--- a/packages/project/src/v4-specification.ts
+++ b/packages/project/src/v4-specification.ts
@@ -1911,7 +1911,6 @@ export interface SolidOrganicMatterEvent extends OrganicMatterEvent {
    * Amount of organic matter or manure applied per acre (in tons per acre for solid/dry organic matter or gallons per acre for slurry).
    *
    * @minimum 0
-   * @maximum 200
    * @example <caption>When the amount of organic matter or manure applied to the crop per acre was 2 tons per acre for a solid/dry manure:</caption>
    *
    * ```js


### PR DESCRIPTION
This update removes the max value for "gallonsPerAcre" from the v4 spec.

This is necessary, because the different types of organic matter slurry each have different maximum values that relate to their moisture content. Validation for maximum gallons per acre will be managed outside of the json specification