### PR TITLE
Make minting error more generic

### DIFF
--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -351,8 +351,8 @@ export const Errors = {
     emptyBatch: {
       message: 'Cannot mint empty batch of removals',
     },
-    missingProjectData: {
-      message: 'Missing required project metadata',
+    missingData: {
+      message: 'Missing required data for minting',
     },
     scheduleDurationNotSet: {
       message:


### PR DESCRIPTION
to accommodate situations where supplier data may be the data that's missing